### PR TITLE
Fixing AndroidBuild to work with 'test'

### DIFF
--- a/autoload/android.vim
+++ b/autoload/android.vim
@@ -238,15 +238,13 @@ function! android#compile(mode)
   endif
 
   if(android#isGradleProject())
-    "if mode == 'release' or 'debug' it should add 'assemble' (eg. assembleRelease)
-    if (a:mode !~ 'assemble')
-      if (a:mode =~ 'release' || a:mode =~ 'debug') 
-        let l:result = s:compile('assemble' . android#capitalize(a:mode))
-        return
-      endif
+    if (a:mode =~ '^test') "Starts with 'test' (allows eg. :AndroidBuild test --debug)
+      let l:result = s:compile(a:mode)
+      return
+    elseif (a:mode !~# '^assemble')
+      let l:result = s:compile('assemble' . android#capitalize(a:mode))
+      return
     endif
-
-    "for 'test' or others it should just execute the command
     let l:result = s:compile(a:mode)
   else
     let l:result = s:compile(a:mode)


### PR DESCRIPTION
A small fix so that next to the `:AndroidBuild release` command you can now also do `:AndroidBuild test`. And I've made `:AndroidBuild assembleRelease` work as well.
