### PR TITLE
Upgraded XML completion

### DIFF
--- a/after/ftplugin/xml.vim
+++ b/after/ftplugin/xml.vim
@@ -1,6 +1,13 @@
 if gradle#isGradleProject()
+
+  call gradle#setClassPath()
+  call gradle#setupGradleCommands()
+
   if android#isAndroidProject()
-    autocmd BufEnter *.xml XMLns android
-    autocmd BufEnter AndroidManifest.xml XMLns manifest
+    XMLns android
+    call android#setAndroidSdkTags()
+    call android#setClassPath()
+    call android#setupAndroidCommands()
   endif
+
 endif

--- a/after/ftplugin/xml.vim
+++ b/after/ftplugin/xml.vim
@@ -1,12 +1,6 @@
 if gradle#isGradleProject()
-
-  call gradle#setClassPath()
-  call gradle#setupGradleCommands()
-
   if android#isAndroidProject()
-    call android#setAndroidSdkTags()
-    call android#setClassPath()
-    call android#setupAndroidCommands()
+    autocmd BufEnter *.xml XMLns android
+    autocmd BufEnter AndroidManifest.xml XMLns manifest
   endif
-
 endif

--- a/autoload/xml/android.vim
+++ b/autoload/xml/android.vim
@@ -1,0 +1,1191 @@
+" Vim XML data file
+" Last Change: 2015-09-17
+
+let g:xmldata_android = {
+\ 'vimxmlentities': ['lt', 'gt', 'amp', 'apos', 'quot'],
+\ 'vimxmlroot': ['ActionMenuView', 'Button', 'CheckBox', 'CheckedTextView', 'Chronometer', 'ContactsAccountType', 'ContactsSource', 'DatePicker', 'DateTimeView', 'EditText', 'ExpandableListView', 'FrameLayout', 'Gallery', 'GridLayout', 'GridView', 'HorizontalScrollView', 'ImageButton', 'ImageView', 'Keyboard', 'LinearLayout', 'ListView', 'MenuItemView', 'PreferenceScreen', 'ProgressBar', 'RadioButton', 'RelativeLayout', 'ScrollView', 'SearchView', 'Switch', 'TabHost', 'TableLayout', 'TextView', 'TimePicker', 'TvInputs', 'TwoLineListItem', 'View', 'WebView', 'accessibility-service', 'account-authenticator', 'allowed_callers', 'alpha', 'android.gesture.GestureOverlayView', 'android.inputmethodservice.ExtractEditLayout', 'android.opengl.GLSurfaceView', 'android.support.design.widget.CoordinatorLayout', 'android.support.v4.view.ViewPager', 'android.support.v4.widget.DrawerLayout', 'android.support.v4.widget.SwipeRefreshLayout', 'android.support.v7.widget.GridLayout', 'android.support.wearable.view.ActionPage', 'android.support.wearable.view.BoxInsetLayout', 'android.support.wearable.view.CardScrollView', 'android.support.wearable.view.GridViewPager', 'android.support.wearable.view.WearableListView', 'android.widget.SimpleMonthView', 'android.widget.TextViewWithCircularIndicator', 'animator', 'appwidget-provider', 'automotiveApp', 'changeBounds', 'com.android.internal.policy.impl.RecentApplicationsBackground', 'com.android.internal.view.menu.ActionMenuItemView', 'com.android.internal.view.menu.ActionMenuView', 'com.android.internal.view.menu.ExpandedMenuView', 'com.android.internal.view.menu.IconMenuItemView', 'com.android.internal.view.menu.ListMenuItemView', 'com.android.internal.widget.AccessibleDateAnimator', 'com.android.internal.widget.ActionBarContextView', 'com.android.internal.widget.ActionBarOverlayLayout', 'com.android.internal.widget.ButtonBarLayout', 'com.android.internal.widget.DialogViewAnimator', 'com.android.internal.widget.ResolverDrawerLayout', 'com.android.internal.widget.SwipeDismissLayout', 'com.android.internal.widget.TransportControlView', 'com.example.android.apis.view.CheckableFrameLayout', 'com.example.android.apis.view.CustomLayout', 'com.example.android.apis.view.SecureViewOverlay', 'com.example.android.batchstepsensor.cardstream.CardActionButton', 'com.example.android.batchstepsensor.cardstream.CardLayout', 'com.example.android.customchoicelist.CheckableLinearLayout', 'com.example.android.elevationdrag.DragFrameLayout', 'com.example.android.softkeyboard.LatinKeyboardView', 'com.example.android.support.wearable.notifications.WearableListItemLayout', 'com.example.android.swiperefreshmultipleviews.MultiSwipeRefreshLayout', 'com.example.android.wearable.flashlight.PartyLightView', 'com.example.android.wearable.speedtracker.ui.SpeedPickerLayout', 'com.example.android.wearable.timer.WearableListItemLayout', 'cursor-adapter', 'cycleInterpolator', 'device-admin', 'explode', 'fragment', 'full-backup-content', 'gridLayoutAnimation', 'host-apdu-service', 'input-method', 'layer-list', 'layoutAnimation', 'level-list', 'menu', 'merge', 'nine-patch', 'objectAnimator', 'preference-headers', 'project', 'recognition-service', 'resources', 'restrictions', 'ripple', 'rotate', 'searchable', 'selector', 'set', 'shape', 'spell-checker', 'sync-adapter', 'transitionManager', 'transitionSet', 'translate', 'tts-engine', 'tv-input', 'vector', 'view', 'wallpaper'],
+\ 'android.support.wearable.view.WearableListView': [
+\ [],
+\ {'android:background': [], 'android:dividerHeight': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:scrollbars': [], 'support:layout_box': []}
+\ ],
+\ 'com.example.android.activityscenetransitionbasic.SquareFrameLayout': [
+\ ['ImageView'],
+\ {'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'com.example.android.apis.accessibility.TaskListView': [
+\ [],
+\ {'android:drawSelectorOnTop': [], 'android:id': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginTop': [], 'android:layout_weight': [], 'android:layout_width': []}
+\ ],
+\ 'com.android.internal.view.menu.ExpandedMenuView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'disable-camera': [
+\ [],
+\ {}
+\ ],
+\ 'extra': [
+\ [],
+\ {'android:name': [], 'android:value': []}
+\ ],
+\ 'com.android.internal.widget.ResolverDrawerLayout': [
+\ ['LinearLayout', 'ListView', 'TextView'],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:maxCollapsedHeight': [], 'android:maxCollapsedHeightSmall': [], 'android:maxWidth': []}
+\ ],
+\ 'com.example.android.softkeyboard.LatinKeyboardView': [
+\ [],
+\ {'android:id': [], 'android:layout_alignParentBottom': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'limit-password': [
+\ [],
+\ {}
+\ ],
+\ 'requestFocus': [
+\ [],
+\ {}
+\ ],
+\ 'com.android.internal.widget.ButtonBarLayout': [
+\ ['Button', 'Space'],
+\ {'android:allowStacking': [], 'android:gravity': [], 'android:id': [], 'android:layoutDirection': [], 'android:layout_height': [], 'android:layout_width': [], 'android:orientation': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingStart': [], 'android:paddingTop': [], 'style': []}
+\ ],
+\ 'Gallery': [
+\ [],
+\ {'android:background': [], 'android:gravity': [], 'android:id': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentLeft': [], 'android:layout_height': [], 'android:layout_width': [], 'android:spacing': []}
+\ ],
+\ 'com.example.android.ui.accessibility.BasicAccessibility.DialView': [
+\ [],
+\ {'android:id': [], 'android:layout_alignLeft': [], 'android:layout_below': [], 'android:layout_height': [], 'android:layout_width': [], 'android:nextFocusUp': []}
+\ ],
+\ 'PreferenceScreen': [
+\ ['CheckBoxPreference', 'EditTextPreference', 'ListPreference', 'MultiSelectListPreference', 'PreferenceCategory', 'com.example.android.apis.app.MyPreference', 'com.example.android.apis.preference.MyPreference', 'extra', 'intent'],
+\ {'android:fragment': [], 'android:key': [], 'android:summary': [], 'android:title': []}
+\ ],
+\ 'com.example.android.apis.view.SecureViewOverlay': [
+\ ['Button', 'TextView'],
+\ {'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'com.android.internal.widget.LockPatternView': [
+\ [],
+\ {'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginTop': [], 'android:layout_rowSpan': [], 'android:layout_width': []}
+\ ],
+\ 'small': [
+\ [],
+\ {}
+\ ],
+\ 'RadioButton': [
+\ [],
+\ {'android:checked': [], 'android:clickable': [], 'android:drawableLeft': [], 'android:duplicateParentState': [], 'android:focusable': [], 'android:gravity': [], 'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginStart': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:onClick': [], 'android:paddingEnd': [], 'android:paddingRight': [], 'android:text': []}
+\ ],
+\ 'android.inputmethodservice.ExtractButton': [
+\ [],
+\ {'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_width': [], 'android:text': [], 'android:visibility': []}
+\ ],
+\ 'ViewStub': [
+\ [],
+\ {'android:id': [], 'android:inflatedId': [], 'android:layout': [], 'android:layout_height': [], 'android:layout_marginEnd': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:theme': [], 'android:visibility': []}
+\ ],
+\ 'item': [
+\ ['bitmap', 'menu', 'objectAnimator', 'ripple', 'rotate', 'scale', 'shape'],
+\ {'android:actionProviderClass': [], 'android:actionViewClass': [], 'android:alphabeticShortcut': [], 'android:bottom': [], 'android:checkable': [], 'android:checked': [], 'android:color': [], 'android:drawable': [], 'android:enabled': [], 'android:icon': [], 'android:id': [], 'android:left': [], 'android:maxLevel': [], 'android:onClick': [], 'android:orderInCategory': [], 'android:right': [], 'android:showAsAction': [], 'android:state_checked': [], 'android:state_enabled': [], 'android:state_focused': [], 'android:state_hovered': [], 'android:state_pressed': [], 'android:state_selected': [], 'android:state_window_focused': [], 'android:title': [], 'android:top': [], 'android:visible': [], 'name': [], 'quantity': [], 'support:actionProviderClass': [], 'support:showAsAction': [], 'type': []}
+\ ],
+\ 'com.android.internal.widget.DialogViewAnimator': [
+\ ['android.widget.DayPickerView', 'android.widget.YearPickerView'],
+\ {'android:gravity': [], 'android:id': [], 'android:inAnimation': [], 'android:layout_height': [], 'android:layout_width': [], 'android:measureAllChildren': [], 'android:outAnimation': []}
+\ ],
+\ 'targets': [
+\ ['target'],
+\ {}
+\ ],
+\ 'com.example.android.basicaccessibility.DialView': [
+\ [],
+\ {'android:id': [], 'android:layout_alignLeft': [], 'android:layout_below': [], 'android:layout_height': [], 'android:layout_width': [], 'android:nextFocusUp': []}
+\ ],
+\ 'selector': [
+\ ['item'],
+\ {'android:enterFadeDuration': []}
+\ ],
+\ 'com.android.internal.widget.SwipeDismissLayout': [
+\ [],
+\ {'android:fitsSystemWindows': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'tech': [
+\ [],
+\ {}
+\ ],
+\ 'shape': [
+\ ['corners', 'gradient', 'padding', 'size', 'solid', 'stroke'],
+\ {'android:innerRadiusRatio': [], 'android:shape': [], 'android:thicknessRatio': [], 'android:useLevel': []}
+\ ],
+\ 'ViewAnimator': [
+\ ['ScrollView', 'fragment'],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': []}
+\ ],
+\ 'host-apdu-service': [
+\ ['aid-group'],
+\ {'android:description': [], 'android:requireDeviceUnlock': []}
+\ ],
+\ 'NumberPicker': [
+\ [],
+\ {'android:focusable': [], 'android:focusableInTouchMode': [], 'android:id': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_width': []}
+\ ],
+\ 'com.example.android.visualgamecontroller.ControllerView': [
+\ [],
+\ {'android:background': [], 'android:id': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:padding': [], 'support:autoCenterPointerInSlice': [], 'support:highlightStrength': [], 'support:labelColor': [], 'support:labelHeight': [], 'support:labelPosition': [], 'support:labelWidth': [], 'support:labelY': [], 'support:pieRotation': [], 'support:pointerRadius': [], 'support:showText': []}
+\ ],
+\ 'com.example.android.displayingbitmaps.ui.RecyclingImageView': [
+\ [],
+\ {'android:contentDescription': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'tv-input': [
+\ [],
+\ {'android:settingsActivity': [], 'android:setupActivity': []}
+\ ],
+\ 'changeTransform': [
+\ [],
+\ {}
+\ ],
+\ 'android.support.wearable.view.CircledImageView': [
+\ [],
+\ {'android:id': [], 'android:layout_below': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginEnd': [], 'android:layout_marginStart': [], 'android:layout_toLeftOf': [], 'android:layout_toRightOf': [], 'android:layout_width': [], 'android:onClick': [], 'android:src': [], 'support:circle_border_color': [], 'support:circle_border_width': [], 'support:circle_color': [], 'support:circle_padding': [], 'support:circle_radius': [], 'support:circle_radius_pressed': []}
+\ ],
+\ 'android.widget.DayPickerView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'com.example.android.wearable.timer.WearableListItemLayout': [
+\ ['ImageView', 'TextView'],
+\ {'android:gravity': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'android.support.design.widget.FloatingActionButton': [
+\ [],
+\ {'android:clickable': [], 'android:id': [], 'android:layout_height': [], 'android:layout_marginStart': [], 'android:layout_width': [], 'android:src': [], 'support:layout_anchor': [], 'support:layout_anchorGravity': [], 'support:rippleColor': []}
+\ ],
+\ 'font': [
+\ ['b', 'sup'],
+\ {'color': [], 'face': [], 'fgcolor': []}
+\ ],
+\ 'android.widget.RadialTimePickerView': [
+\ [],
+\ {'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginEnd': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_width': []}
+\ ],
+\ 'b': [
+\ ['i'],
+\ {}
+\ ],
+\ 'style': [
+\ ['item'],
+\ {'name': [], 'parent': []}
+\ ],
+\ 'android.support.design.widget.CoordinatorLayout': [
+\ ['LinearLayout', 'android.support.design.widget.FloatingActionButton'],
+\ {'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'ActionMenuView': [
+\ [],
+\ {'android:divider': [], 'android:dividerPadding': [], 'android:gravity': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'wipe-data': [
+\ [],
+\ {}
+\ ],
+\ 'com.example.android.lunarlander.LunarView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'gridLayoutAnimation': [
+\ [],
+\ {'android:animation': [], 'android:columnDelay': [], 'android:direction': [], 'android:directionPriority': [], 'android:rowDelay': []}
+\ ],
+\ 'TableRow': [
+\ ['Button', 'EditText', 'ImageView', 'RelativeLayout', 'Space', 'Spinner', 'TextView', 'View'],
+\ {'android:gravity': [], 'android:layoutAnimation': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'com.example.android.apis.preference.MyPreference': [
+\ [],
+\ {'android:defaultValue': [], 'android:key': [], 'android:summary': [], 'android:title': []}
+\ ],
+\ 'GridView': [
+\ [],
+\ {'android:alwaysDrawnWithCache': [], 'android:background': [], 'android:clipToPadding': [], 'android:columnWidth': [], 'android:drawSelectorOnTop': [], 'android:fadingEdge': [], 'android:gravity': [], 'android:horizontalSpacing': [], 'android:id': [], 'android:layoutAnimation': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:listSelector': [], 'android:numColumns': [], 'android:padding': [], 'android:paddingBottom': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:persistentDrawingCache': [], 'android:scrollbarStyle': [], 'android:scrollbars': [], 'android:stackFromBottom': [], 'android:stretchMode': [], 'android:verticalSpacing': [], 'android:visibility': [], 'style': [], 'tools:context': []}
+\ ],
+\ 'TvInputs': [
+\ ['Channels'],
+\ {'description': [], 'display_name': [], 'logo_background_url': [], 'logo_thumb_url': [], 'name': []}
+\ ],
+\ 'com.android.internal.widget.ActionBarContextView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:visibility': [], 'style': []}
+\ ],
+\ 'cycleInterpolator': [
+\ [],
+\ {'android:cycles': []}
+\ ],
+\ 'android.support.v7.widget.GridLayout': [
+\ ['Button', 'EditText', 'TextView'],
+\ {'android:alignmentMode': [], 'android:columnCount': [], 'android:layout_height': [], 'android:layout_width': [], 'android:rowOrderPreserved': [], 'android:useDefaultMargins': []}
+\ ],
+\ 'android.support.wearable.view.DotsPageIndicator': [
+\ [],
+\ {'android:background': [], 'android:id': [], 'android:layout_alignParentBottom': [], 'android:layout_centerHorizontal': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_width': [], 'android:padding': [], 'android:visibility': [], 'support:dotFadeWhenIdle': []}
+\ ],
+\ 'cursor-adapter': [
+\ ['bind'],
+\ {}
+\ ],
+\ 'translate': [
+\ [],
+\ {'android:duration': [], 'android:fromXDelta': [], 'android:fromYDelta': [], 'android:interpolator': [], 'android:toXDelta': [], 'android:toYDelta': []}
+\ ],
+\ 'full-backup-content': [
+\ ['exclude'],
+\ {}
+\ ],
+\ 'merge': [
+\ ['EditText', 'ImageButton', 'ImageView', 'LinearLayout', 'ListView', 'RelativeLayout', 'TextView', 'ViewStub', 'ZoomButton', 'ZoomControls', 'android.support.wearable.view.CircledImageView', 'com.example.android.snake.BackgroundView', 'com.example.android.snake.SnakeView', 'view'],
+\ {}
+\ ],
+\ 'pathelement': [
+\ [],
+\ {'path': []}
+\ ],
+\ 'device-admin': [
+\ ['uses-policies'],
+\ {}
+\ ],
+\ 'accessibility-service': [
+\ [],
+\ {'android:accessibilityEventTypes': [], 'android:accessibilityFeedbackType': [], 'android:canRetrieveWindowContent': [], 'android:description': [], 'android:notificationTimeout': [], 'android:packageNames': []}
+\ ],
+\ 'android.widget.TextViewWithCircularIndicator': [
+\ [],
+\ {'android:gravity': [], 'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'com.example.android.hdrviewfinder.FixedAspectSurfaceView': [
+\ [],
+\ {'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'support:aspectRatio': []}
+\ ],
+\ 'com.example.android.apis.app.MyPreference': [
+\ [],
+\ {'android:defaultValue': [], 'android:key': [], 'android:summary': [], 'android:title': []}
+\ ],
+\ 'com.example.android.apis.view.CustomLayout': [
+\ ['TextView'],
+\ {'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'intent': [
+\ [],
+\ {'android:action': [], 'android:data': []}
+\ ],
+\ 'com.android.internal.widget.DigitalClock': [
+\ ['TextView'],
+\ {'android:id': [], 'android:layout_gravity': [], 'android:layout_marginBottom': [], 'android:layout_marginRight': [], 'android:layout_marginTop': [], 'android:layout_rowSpan': []}
+\ ],
+\ 'map': [
+\ [],
+\ {}
+\ ],
+\ 'a': [
+\ [],
+\ {'href': []}
+\ ],
+\ 'CheckBox': [
+\ [],
+\ {'android:background': [], 'android:button': [], 'android:checked': [], 'android:clickable': [], 'android:duplicateParentState': [], 'android:focusable': [], 'android:gravity': [], 'android:id': [], 'android:layout_alignLeft': [], 'android:layout_alignParentLeft': [], 'android:layout_alignParentStart': [], 'android:layout_below': [], 'android:layout_centerVertical': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:maxLines': [], 'android:nextFocusDown': [], 'android:nextFocusUp': [], 'android:onClick': [], 'android:paddingBottom': [], 'android:paddingTop': [], 'android:text': [], 'android:textAppearance': [], 'android:textColor': [], 'android:textSize': [], 'android:visibility': [], 'style': []}
+\ ],
+\ 'android.support.wearable.view.CardScrollView': [
+\ ['android.support.wearable.view.CardFrame'],
+\ {'android:clipToPadding': [], 'android:layout_height': [], 'android:layout_width': [], 'android:paddingBottom': []}
+\ ],
+\ 'recognition-service': [
+\ [],
+\ {'android:settingsActivity': []}
+\ ],
+\ 'CalendarView': [
+\ [],
+\ {'android:focusable': [], 'android:focusableInTouchMode': [], 'android:id': [], 'android:layout_height': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:visibility': []}
+\ ],
+\ 'android.inputmethodservice.ExtractEditLayout': [
+\ ['FrameLayout', 'android.inputmethodservice.ExtractEditText'],
+\ {'android:orientation': []}
+\ ],
+\ 'rotate': [
+\ ['shape'],
+\ {'android:drawable': [], 'android:duration': [], 'android:fillAfter': [], 'android:fillBefore': [], 'android:fillEnabled': [], 'android:fromDegrees': [], 'android:pivotX': [], 'android:pivotY': [], 'android:startOffset': [], 'android:toDegrees': [], 'android:toYScale': []}
+\ ],
+\ 'com.example.android.batchstepsensor.cardstream.CardStreamLinearLayout': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'style': []}
+\ ],
+\ 'Keyboard': [
+\ ['Row'],
+\ {'android:horizontalGap': [], 'android:keyHeight': [], 'android:keyWidth': [], 'android:verticalGap': []}
+\ ],
+\ 'com.example.android.apis.view.HoverInterceptorView': [
+\ ['Button', 'TextView'],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:orientation': []}
+\ ],
+\ 'ContactsSource': [
+\ ['ContactsDataKind'],
+\ {}
+\ ],
+\ 'android.inputmethodservice.ExtractEditText': [
+\ [],
+\ {'android:gravity': [], 'android:id': [], 'android:inputType': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:minLines': [], 'android:scrollbars': []}
+\ ],
+\ 'com.android.internal.widget.PreferenceImageView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:maxHeight': [], 'android:maxWidth': []}
+\ ],
+\ 'View': [
+\ [],
+\ {'android:background': [], 'android:elevation': [], 'android:gravity': [], 'android:id': [], 'android:layout_above': [], 'android:layout_alignBottom': [], 'android:layout_alignLeft': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentLeft': [], 'android:layout_alignParentRight': [], 'android:layout_alignParentTop': [], 'android:layout_alignRight': [], 'android:layout_alignTop': [], 'android:layout_alignWithParentIfMissing': [], 'android:layout_below': [], 'android:layout_centerHorizontal': [], 'android:layout_centerInParent': [], 'android:layout_centerVertical': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_margin': [], 'android:layout_marginBottom': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginTop': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:minHeight': [], 'android:minWidth': [], 'android:visibility': [], 'style': []}
+\ ],
+\ 'android.widget.YearPickerView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:scrollIndicators': []}
+\ ],
+\ 'restrictions': [
+\ ['restriction'],
+\ {}
+\ ],
+\ 'android.support.v4.widget.DrawerLayout': [
+\ ['FrameLayout', 'android.support.v7.widget.RecyclerView'],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'transitionManager': [
+\ ['transition'],
+\ {}
+\ ],
+\ 'RelativeLayout': [
+\ ['Button', 'CheckBox', 'EditText', 'FrameLayout', 'Gallery', 'ImageButton', 'ImageSwitcher', 'ImageView', 'LinearLayout', 'ListView', 'ProgressBar', 'QuickContactBadge', 'RadioGroup', 'RelativeLayout', 'SeekBar', 'Spinner', 'SurfaceView', 'TextView', 'ToggleButton', 'VideoView', 'View', 'android.support.v4.view.ViewPager', 'android.support.wearable.view.CircledImageView', 'android.support.wearable.view.DotsPageIndicator', 'android.support.wearable.view.GridViewPager', 'android.support.wearable.view.WearableListView', 'com.android.internal.widget.multiwaveview.MultiWaveView', 'com.example.android.apis.view.DraggableDot', 'com.example.android.basicaccessibility.DialView', 'com.example.android.camera2basic.AutoFitTextureView', 'com.example.android.camera2raw.AutoFitTextureView', 'com.example.android.camera2video.AutoFitTextureView', 'com.example.android.ui.accessibility.BasicAccessibility.DialView', 'fragment', 'include'],
+\ {'android:background': [], 'android:clickable': [], 'android:clipChildren': [], 'android:clipToPadding': [], 'android:duplicateParentState': [], 'android:focusable': [], 'android:gravity': [], 'android:id': [], 'android:layout_alignBottom': [], 'android:layout_alignLeft': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentTop': [], 'android:layout_alignRight': [], 'android:layout_alignTop': [], 'android:layout_centerHorizontal': [], 'android:layout_centerInParent': [], 'android:layout_centerVertical': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:minHeight': [], 'android:onClick': [], 'android:orientation': [], 'android:padding': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:tag': [], 'android:visibility': [], 'style': [], 'support:layout_box': [], 'tools:context': [], 'tools:ignore': []}
+\ ],
+\ 'setup': [
+\ [],
+\ {}
+\ ],
+\ 'SurfaceView': [
+\ [],
+\ {'android:id': [], 'android:layout_alignParentTop': [], 'android:layout_centerHorizontal': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': []}
+\ ],
+\ 'com.android.internal.widget.TransportControlView': [
+\ ['FrameLayout', 'LinearLayout'],
+\ {'android:id': []}
+\ ],
+\ 'aid-filter': [
+\ [],
+\ {'android:name': []}
+\ ],
+\ 'com.example.android.apis.view.LabelView': [
+\ [],
+\ {'android:background': [], 'android:layout_height': [], 'android:layout_width': [], 'app:text': [], 'app:textColor': [], 'app:textSize': []}
+\ ],
+\ 'EditText': [
+\ ['requestFocus'],
+\ {'android:allowUndo': [], 'android:autoText': [], 'android:background': [], 'android:capitalize': [], 'android:clickable': [], 'android:ems': [], 'android:focusable': [], 'android:focusableInTouchMode': [], 'android:fontFamily': [], 'android:freezesText': [], 'android:gravity': [], 'android:hint': [], 'android:id': [], 'android:imeOptions': [], 'android:inputType': [], 'android:layout_alignBaseline': [], 'android:layout_alignParentRight': [], 'android:layout_alignParentStart': [], 'android:layout_alignStart': [], 'android:layout_below': [], 'android:layout_column': [], 'android:layout_columnSpan': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_margin': [], 'android:layout_marginBottom': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_toRightOf': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:lines': [], 'android:maxEms': [], 'android:maxLength': [], 'android:maxLines': [], 'android:maxWidth': [], 'android:minEms': [], 'android:minWidth': [], 'android:nextFocusDown': [], 'android:nextFocusRight': [], 'android:padding': [], 'android:paddingBottom': [], 'android:password': [], 'android:privateImeOptions': [], 'android:scrollHorizontally': [], 'android:selectAllOnFocus': [], 'android:singleLine': [], 'android:text': [], 'android:textAppearance': [], 'android:textColor': [], 'android:textSize': [], 'android:textStyle': [], 'android:visibility': [], 'android:width': [], 'style': []}
+\ ],
+\ 'com.android.internal.widget.ActionBarContainer': [
+\ ['Toolbar', 'com.android.internal.widget.ActionBarContextView', 'com.android.internal.widget.ActionBarView'],
+\ {'android:gravity': [], 'android:id': [], 'android:layout_alignParentTop': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_width': [], 'android:touchscreenBlocksFocus': [], 'android:transitionName': [], 'android:visibility': [], 'style': []}
+\ ],
+\ 'tech-list': [
+\ ['tech'],
+\ {}
+\ ],
+\ 'Switch': [
+\ [],
+\ {'android:background': [], 'android:checked': [], 'android:clickable': [], 'android:enabled': [], 'android:focusable': [], 'android:gravity': [], 'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_margin': [], 'android:layout_marginBottom': [], 'android:layout_marginEnd': [], 'android:layout_marginRight': [], 'android:layout_marginTop': [], 'android:layout_width': [], 'android:padding': [], 'android:paddingEnd': [], 'android:paddingStart': [], 'android:singleLine': [], 'android:text': [], 'android:textAppearance': [], 'android:textOff': [], 'android:textOn': []}
+\ ],
+\ 'com.example.android.support.wearable.notifications.WearableListItemLayout': [
+\ ['ImageView', 'TextView'],
+\ {'android:gravity': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'android.support.wearable.view.WatchViewStub': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'support:rectLayout': [], 'support:roundLayout': []}
+\ ],
+\ 'disable-keyguard-features': [
+\ [],
+\ {}
+\ ],
+\ 'wallpaper': [
+\ [],
+\ {'android:settingsActivity': []}
+\ ],
+\ 'encrypted-storage': [
+\ [],
+\ {}
+\ ],
+\ 'expire-password': [
+\ [],
+\ {}
+\ ],
+\ 'com.example.android.snake.BackgroundView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'VideoView': [
+\ [],
+\ {'android:id': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentLeft': [], 'android:layout_alignParentRight': [], 'android:layout_alignParentTop': [], 'android:layout_centerInParent': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'aid-group': [
+\ ['aid-filter'],
+\ {'android:category': [], 'android:description': []}
+\ ],
+\ 'nine-patch': [
+\ [],
+\ {'android:src': [], 'android:tint': [], 'android:tintMode': []}
+\ ],
+\ 'com.android.internal.view.menu.ListMenuItemView': [
+\ ['RelativeLayout'],
+\ {'android:layout_height': [], 'android:layout_width': [], 'android:minWidth': [], 'android:paddingEnd': [], 'android:paddingRight': []}
+\ ],
+\ 'com.example.android.elevationdrag.DragFrameLayout': [
+\ ['LinearLayout', 'View'],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'tools:context': []}
+\ ],
+\ 'ViewFlipper': [
+\ ['TextView'],
+\ {'android:flipInterval': [], 'android:id': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_width': []}
+\ ],
+\ 'ProgressBar': [
+\ [],
+\ {'android:id': [], 'android:indeterminate': [], 'android:indeterminateBehavior': [], 'android:indeterminateDrawable': [], 'android:indeterminateDuration': [], 'android:indeterminateOnly': [], 'android:layout_alignParentEnd': [], 'android:layout_alignParentLeft': [], 'android:layout_alignParentRight': [], 'android:layout_alignParentStart': [], 'android:layout_centerHorizontal': [], 'android:layout_centerInParent': [], 'android:layout_centerVertical': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_toEndOf': [], 'android:layout_toLeftOf': [], 'android:layout_toRightOf': [], 'android:layout_toStartOf': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:max': [], 'android:padding': [], 'android:progress': [], 'android:secondaryProgress': [], 'android:visibility': [], 'style': []}
+\ ],
+\ 'fragment': [
+\ [],
+\ {'android:id': [], 'android:label': [], 'android:layout_below': [], 'android:layout_height': [], 'android:layout_margin': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:name': [], 'class': [], 'tools:context': [], 'tools:layout': []}
+\ ],
+\ 'com.android.internal.widget.multiwaveview.MultiWaveView': [
+\ [],
+\ {'android:directionDescriptions': [], 'android:feedbackCount': [], 'android:handleDrawable': [], 'android:hitRadius': [], 'android:horizontalOffset': [], 'android:id': [], 'android:layout_alignParentBottom': [], 'android:layout_height': [], 'android:layout_rowSpan': [], 'android:layout_width': [], 'android:orientation': [], 'android:outerRadius': [], 'android:rightChevronDrawable': [], 'android:snapMargin': [], 'android:targetDescriptions': [], 'android:targetDrawables': [], 'android:topChevronDrawable': [], 'android:verticalOffset': [], 'android:vibrationDuration': [], 'android:waveDrawable': []}
+\ ],
+\ 'watch-login': [
+\ [],
+\ {}
+\ ],
+\ 'uses': [
+\ [],
+\ {'name': []}
+\ ],
+\ 'com.example.android.jetboy.JetBoyView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'Key': [
+\ [],
+\ {'android:codes': [], 'android:horizontalGap': [], 'android:isModifier': [], 'android:isRepeatable': [], 'android:isSticky': [], 'android:keyEdgeFlags': [], 'android:keyIcon': [], 'android:keyLabel': [], 'android:keyWidth': []}
+\ ],
+\ 'size': [
+\ [],
+\ {'android:height': [], 'android:width': []}
+\ ],
+\ 'property': [
+\ [],
+\ {'file': []}
+\ ],
+\ 'RatingBar': [
+\ [],
+\ {'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginLeft': [], 'android:layout_width': [], 'android:numStars': [], 'android:rating': [], 'style': []}
+\ ],
+\ 'target': [
+\ [],
+\ {'android:excludeId': [], 'android:targetClass': [], 'android:targetId': []}
+\ ],
+\ 'TextClock': [
+\ [],
+\ {'android:format12Hour': [], 'android:format24Hour': [], 'android:layout_height': [], 'android:layout_width': [], 'android:shadowColor': [], 'android:shadowRadius': [], 'android:textSize': [], 'android:timeZone': []}
+\ ],
+\ 'com.example.android.floatingactionbuttonbasic.FloatingActionButton': [
+\ ['ImageView'],
+\ {'android:background': [], 'android:elevation': [], 'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginTop': [], 'android:layout_width': [], 'android:stateListAnimator': []}
+\ ],
+\ 'menu': [
+\ ['group', 'item'],
+\ {'tools:context': []}
+\ ],
+\ 'animator': [
+\ ['propertyValuesHolder'],
+\ {'android:duration': [], 'android:repeatCount': [], 'android:repeatMode': [], 'android:valueFrom': [], 'android:valueTo': [], 'android:valueType': []}
+\ ],
+\ 'explode': [
+\ ['targets'],
+\ {}
+\ ],
+\ 'com.google.android.exoplayer.text.SubtitleView': [
+\ [],
+\ {'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_width': [], 'android:visibility': []}
+\ ],
+\ 'padding': [
+\ [],
+\ {'android:bottom': [], 'android:left': [], 'android:right': [], 'android:top': []}
+\ ],
+\ 'com.example.android.input.multitouch.basicMultitouch.TouchDisplayView': [
+\ [],
+\ {'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'AutoCompleteTextView': [
+\ [],
+\ {'android:completionHint': [], 'android:completionThreshold': [], 'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_width': [], 'android:singleLine': []}
+\ ],
+\ 'Toolbar': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:navigationContentDescription': [], 'style': []}
+\ ],
+\ 'android.support.v7.widget.RecyclerView': [
+\ [],
+\ {'android:choiceMode': [], 'android:divider': [], 'android:drawSelectorOnTop': [], 'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_width': [], 'android:scrollbars': []}
+\ ],
+\ 'changeBounds': [
+\ ['arcMotion'],
+\ {}
+\ ],
+\ 'com.android.internal.policy.impl.RecentApplicationsBackground': [
+\ ['FrameLayout', 'LinearLayout', 'TextView'],
+\ {'android:background': [], 'android:gravity': [], 'android:layout_height': [], 'android:layout_width': [], 'android:orientation': [], 'android:padding': []}
+\ ],
+\ 'level-list': [
+\ ['item'],
+\ {}
+\ ],
+\ 'subtype': [
+\ [],
+\ {'android:icon': [], 'android:imeSubtypeLocale': [], 'android:imeSubtypeMode': [], 'android:label': [], 'android:subtypeLocale': []}
+\ ],
+\ 'automotiveApp': [
+\ ['uses'],
+\ {}
+\ ],
+\ 'com.example.android.camera2video.AutoFitTextureView': [
+\ [],
+\ {'android:id': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentStart': [], 'android:layout_alignParentTop': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'Row': [
+\ ['Key'],
+\ {'android:rowEdgeFlags': []}
+\ ],
+\ 'CheckBoxPreference': [
+\ [],
+\ {'android:defaultValue': [], 'android:dependency': [], 'android:key': [], 'android:layout': [], 'android:persistent': [], 'android:summary': [], 'android:summaryOff': [], 'android:summaryOn': [], 'android:title': []}
+\ ],
+\ 'account-authenticator': [
+\ [],
+\ {'android:accountType': [], 'android:icon': [], 'android:label': [], 'android:smallIcon': []}
+\ ],
+\ 'Space': [
+\ [],
+\ {'android:id': [], 'android:layout_column': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_row': [], 'android:layout_rowSpan': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:visibility': []}
+\ ],
+\ 'include': [
+\ [],
+\ {'android:id': [], 'android:layout_below': [], 'android:layout_column': [], 'android:layout_columnSpan': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_row': [], 'android:layout_rowSpan': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:visibility': [], 'layout': []}
+\ ],
+\ 'TextSwitcher': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'ripple': [
+\ ['item'],
+\ {'android:color': []}
+\ ],
+\ 'android.opengl.GLSurfaceView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': []}
+\ ],
+\ 'com.android.internal.widget.AccessibleDateAnimator': [
+\ [],
+\ {'android:gravity': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'SearchView': [
+\ [],
+\ {'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:maxWidth': []}
+\ ],
+\ 'bitmap': [
+\ [],
+\ {'android:src': [], 'android:tint': []}
+\ ],
+\ 'preference-headers': [
+\ ['header'],
+\ {}
+\ ],
+\ 'sup': [
+\ ['small'],
+\ {}
+\ ],
+\ 'bool': [
+\ [],
+\ {'name': []}
+\ ],
+\ 'stroke': [
+\ [],
+\ {'android:color': [], 'android:dashGap': [], 'android:dashWidth': [], 'android:width': [], 'color': []}
+\ ],
+\ 'header': [
+\ ['extra', 'intent'],
+\ {'android:fragment': [], 'android:icon': [], 'android:summary': [], 'android:title': []}
+\ ],
+\ 'corners': [
+\ [],
+\ {'android:radius': []}
+\ ],
+\ 'view': [
+\ ['ImageView', 'LinearLayout', 'RelativeLayout', 'TextView'],
+\ {'android:background': [], 'android:cacheColorHint': [], 'android:capitalize': [], 'android:clickable': [], 'android:clipToPadding': [], 'android:contentDescription': [], 'android:descendantFocusability': [], 'android:divider': [], 'android:dropDownAnchor': [], 'android:dropDownHeight': [], 'android:dropDownHorizontalOffset': [], 'android:dropDownVerticalOffset': [], 'android:ellipsize': [], 'android:fadingEdge': [], 'android:focusable': [], 'android:gravity': [], 'android:id': [], 'android:imeOptions': [], 'android:inputType': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginTop': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:minWidth': [], 'android:orientation': [], 'android:overScrollMode': [], 'android:padding': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:scaleType': [], 'android:scrollbars': [], 'android:singleLine': [], 'android:src': [], 'android:textAlignment': [], 'android:textAppearance': [], 'android:textSize': [], 'class': [], 'style': []}
+\ ],
+\ 'Channels': [
+\ ['Channel'],
+\ {}
+\ ],
+\ 'RadioGroup': [
+\ ['RadioButton', 'TextView', 'com.example.android.renderscriptintrinsic.ThumbnailRadioButton'],
+\ {'android:checkedButton': [], 'android:gravity': [], 'android:id': [], 'android:layout_above': [], 'android:layout_centerHorizontal': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginLeft': [], 'android:layout_marginTop': [], 'android:layout_width': [], 'android:orientation': []}
+\ ],
+\ 'TabHost': [
+\ ['LinearLayout'],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': []}
+\ ],
+\ 'android.support.wearable.view.DismissOverlayView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'ExpandableListView': [
+\ [],
+\ {'android:drawSelectorOnTop': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'com.example.android.common.logger.LogView': [
+\ [],
+\ {'android:clickable': [], 'android:focusable': [], 'android:gravity': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:text': [], 'style': []}
+\ ],
+\ 'com.example.android.swiperefreshmultipleviews.MultiSwipeRefreshLayout': [
+\ ['FrameLayout'],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'scale': [
+\ [],
+\ {'android:drawable': [], 'android:duration': [], 'android:fillAfter': [], 'android:fillBefore': [], 'android:fillEnabled': [], 'android:fromXScale': [], 'android:fromYScale': [], 'android:interpolator': [], 'android:pivotX': [], 'android:pivotY': [], 'android:scaleWidth': [], 'android:startOffset': [], 'android:toXScale': [], 'android:toYScale': []}
+\ ],
+\ 'MultiAutoCompleteTextView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'android.widget.SimpleMonthView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:paddingEnd': [], 'android:paddingStart': [], 'android:paddingTop': []}
+\ ],
+\ 'ImageButton': [
+\ [],
+\ {'android:adjustViewBounds': [], 'android:background': [], 'android:clickable': [], 'android:contentDescription': [], 'android:focusable': [], 'android:gravity': [], 'android:id': [], 'android:layout_alignBottom': [], 'android:layout_alignParentRight': [], 'android:layout_alignRight': [], 'android:layout_alignTop': [], 'android:layout_centerVertical': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_toRightOf': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:minHeight': [], 'android:minWidth': [], 'android:nextFocusDown': [], 'android:nextFocusUp': [], 'android:padding': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:scaleType': [], 'android:src': [], 'android:visibility': [], 'style': []}
+\ ],
+\ 'Chronometer': [
+\ [],
+\ {'android:format': [], 'android:gravity': [], 'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:paddingBottom': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:singleLine': [], 'android:textAppearance': []}
+\ ],
+\ 'android.support.wearable.view.ActionPage': [
+\ [],
+\ {'android:color': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:maxLines': [], 'android:src': [], 'android:text': [], 'support:rippleColor': []}
+\ ],
+\ 'declare-styleable': [
+\ ['attr'],
+\ {'name': []}
+\ ],
+\ 'android.support.wearable.view.GridViewPager': [
+\ [],
+\ {'android:id': [], 'android:keepScreenOn': [], 'android:layout_height': [], 'android:layout_width': [], 'android:visibility': []}
+\ ],
+\ 'resources': [
+\ ['array', 'attr', 'bool', 'color', 'declare-styleable', 'dimen', 'drawable', 'integer', 'integer-array', 'item', 'plurals', 'skip', 'string', 'string-array', 'style', 'tech-list', 'usb-device'],
+\ {}
+\ ],
+\ 'exclude': [
+\ [],
+\ {'domain': [], 'path': []}
+\ ],
+\ 'signing_certificate': [
+\ [],
+\ {'name': [], 'package': [], 'release': []}
+\ ],
+\ 'usb-device': [
+\ [],
+\ {'class': [], 'product-id': [], 'protocol': [], 'subclass': [], 'vendor-id': []}
+\ ],
+\ 'com.example.android.camera2raw.AutoFitTextureView': [
+\ [],
+\ {'android:id': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentStart': [], 'android:layout_alignParentTop': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'com.example.android.wearable.flashlight.PartyLightView': [
+\ [],
+\ {'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'propertyValuesHolder': [
+\ ['keyframe'],
+\ {'android:propertyName': [], 'android:valueTo': []}
+\ ],
+\ 'WebView': [
+\ [],
+\ {'android:background': [], 'android:focusable': [], 'android:id': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:padding': []}
+\ ],
+\ 'u': [
+\ ['ignore'],
+\ {}
+\ ],
+\ 'tts-engine': [
+\ [],
+\ {'android:settingsActivity': []}
+\ ],
+\ 'com.android.internal.view.menu.ActionMenuItemView': [
+\ ['Button', 'ImageButton'],
+\ {'android:addStatesFromChildren': [], 'android:focusable': [], 'android:gravity': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_width': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:textAppearance': [], 'android:textColor': [], 'style': []}
+\ ],
+\ 'ToggleButton': [
+\ [],
+\ {'android:background': [], 'android:id': [], 'android:layout_centerHorizontal': [], 'android:layout_centerVertical': [], 'android:layout_height': [], 'android:layout_marginTop': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:onClick': [], 'android:text': [], 'android:textOff': [], 'android:textOn': []}
+\ ],
+\ 'android.support.v4.widget.SwipeRefreshLayout': [
+\ ['ListView'],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'com.example.android.wearable.speedtracker.ui.SpeedPickerLayout': [
+\ ['ImageView', 'TextView'],
+\ {'android:gravity': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'Spinner': [
+\ [],
+\ {'android:drawSelectorOnTop': [], 'android:entries': [], 'android:id': [], 'android:layout_alignEnd': [], 'android:layout_alignParentTop': [], 'android:layout_below': [], 'android:layout_centerHorizontal': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginLeft': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_toEndOf': [], 'android:layout_toRightOf': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:prompt': []}
+\ ],
+\ 'gradient': [
+\ [],
+\ {'android:angle': [], 'android:centerColor': [], 'android:centerY': [], 'android:endColor': [], 'android:startColor': [], 'android:type': [], 'android:useLevel': []}
+\ ],
+\ 'com.example.android.camera2basic.AutoFitTextureView': [
+\ [],
+\ {'android:id': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentStart': [], 'android:layout_alignParentTop': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'android.support.v4.view.ViewPager': [
+\ [],
+\ {'android:background': [], 'android:id': [], 'android:keepScreenOn': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'tools:context': []}
+\ ],
+\ 'ZoomButton': [
+\ [],
+\ {'android:background': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'MenuItemView': [
+\ ['ImageView', 'TextView'],
+\ {'android:focusable': [], 'android:orientation': []}
+\ ],
+\ 'android.support.wearable.view.CardFrame': [
+\ ['TextView'],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'changeImageTransform': [
+\ [],
+\ {}
+\ ],
+\ 'ImageView': [
+\ [],
+\ {'android:adjustViewBounds': [], 'android:background': [], 'android:baselineAligned': [], 'android:clickable': [], 'android:contentDescription': [], 'android:drawable': [], 'android:drawableAlpha': [], 'android:duplicateParentState': [], 'android:focusable': [], 'android:gravity': [], 'android:id': [], 'android:layout_above': [], 'android:layout_alignBottom': [], 'android:layout_alignLeft': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentEnd': [], 'android:layout_alignParentLeft': [], 'android:layout_alignParentRight': [], 'android:layout_alignParentStart': [], 'android:layout_alignParentTop': [], 'android:layout_alignRight': [], 'android:layout_alignWithParentIfMissing': [], 'android:layout_below': [], 'android:layout_centerHorizontal': [], 'android:layout_centerVertical': [], 'android:layout_column': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_margin': [], 'android:layout_marginBottom': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_row': [], 'android:layout_toEndOf': [], 'android:layout_toLeftOf': [], 'android:layout_toRightOf': [], 'android:layout_toStartOf': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:maxHeight': [], 'android:maxWidth': [], 'android:minWidth': [], 'android:nextFocusDown': [], 'android:nextFocusUp': [], 'android:onClick': [], 'android:padding': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:scaleType': [], 'android:src': [], 'android:tag': [], 'android:tint': [], 'android:tintMode': [], 'android:transitionName': [], 'android:visibility': [], 'android_paddingRight': [], 'style': [], 'tools:src': []}
+\ ],
+\ 'string': [
+\ ['a', 'b', 'font', 'i', 'u', 'xliff:g'],
+\ {'name': [], 'translatable': []}
+\ ],
+\ 'TextView': [
+\ [],
+\ {'android:autoLink': [], 'android:background': [], 'android:clickable': [], 'android:clipToPadding': [], 'android:color': [], 'android:drawableLeft': [], 'android:drawablePadding': [], 'android:duplicateParentState': [], 'android:elevation': [], 'android:ellipsize': [], 'android:enabled': [], 'android:fadingEdge': [], 'android:fitsSystemWindows': [], 'android:focusable': [], 'android:fontFamily': [], 'android:gravity': [], 'android:id': [], 'android:importantForAccessibility': [], 'android:includeFontPadding': [], 'android:inputType': [], 'android:labelFor': [], 'android:layoutDirection': [], 'android:layout_above': [], 'android:layout_alignBaseline': [], 'android:layout_alignBottom': [], 'android:layout_alignEnd': [], 'android:layout_alignLeft': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentEnd': [], 'android:layout_alignParentLeft': [], 'android:layout_alignParentRight': [], 'android:layout_alignParentStart': [], 'android:layout_alignParentTop': [], 'android:layout_alignRight': [], 'android:layout_alignStart': [], 'android:layout_alignTop': [], 'android:layout_alignWithParentIfMissing': [], 'android:layout_alwaysShow': [], 'android:layout_below': [], 'android:layout_centerHorizontal': [], 'android:layout_centerInParent': [], 'android:layout_centerVertical': [], 'android:layout_column': [], 'android:layout_columnSpan': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_margin': [], 'android:layout_marginBottom': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_row': [], 'android:layout_rowSpan': [], 'android:layout_span': [], 'android:layout_toEndOf': [], 'android:layout_toLeftOf': [], 'android:layout_toRightOf': [], 'android:layout_toStartOf': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:lineSpacingExtra': [], 'android:lineSpacingMultiplier': [], 'android:maxLines': [], 'android:maxWidth': [], 'android:minHeight': [], 'android:minLines': [], 'android:minWidth': [], 'android:nextFocusDown': [], 'android:nextFocusUp': [], 'android:onClick': [], 'android:padding': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:requiresFadingEdge': [], 'android:scrollHorizontally': [], 'android:scrollbars': [], 'android:shadowColor': [], 'android:shadowDx': [], 'android:shadowDy': [], 'android:shadowRadius': [], 'android:singleLine': [], 'android:text': [], 'android:textAlignment': [], 'android:textAllCaps': [], 'android:textAppearance': [], 'android:textColor': [], 'android:textIsSelectable': [], 'android:textSize': [], 'android:textStyle': [], 'android:theme': [], 'android:transitionName': [], 'android:visibility': [], 'android:width': [], 'app:layout_position': [], 'style': [], 'support:layout_box': [], 'tools:text': []}
+\ ],
+\ 'ContactsAccountType': [
+\ ['ContactsDataKind'],
+\ {'inviteContactActionLabel': [], 'inviteContactActivity': [], 'viewContactNotifyService': [], 'viewGroupActionLabel': [], 'viewGroupActivity': [], 'viewStreamItemActivity': [], 'viewStreamItemPhotoActivity': []}
+\ ],
+\ 'drawable': [
+\ [],
+\ {'name': []}
+\ ],
+\ 'LinearLayout': [
+\ ['AutoCompleteTextView', 'Button', 'CalendarView', 'CheckBox', 'CheckedTextView', 'Chronometer', 'DateTimeView', 'EditText', 'ExpandableListView', 'FrameLayout', 'Gallery', 'GridLayout', 'GridView', 'HorizontalScrollView', 'ImageButton', 'ImageView', 'LinearLayout', 'ListView', 'MultiAutoCompleteTextView', 'NumberPicker', 'ProgressBar', 'RadioButton', 'RadioGroup', 'RatingBar', 'RelativeLayout', 'ScrollView', 'SearchView', 'SeekBar', 'Space', 'Spinner', 'SurfaceView', 'Switch', 'TabHost', 'TabWidget', 'TableLayout', 'TextClock', 'TextSwitcher', 'TextView', 'TimePicker', 'ToggleButton', 'TwoLineListItem', 'VideoView', 'View', 'ViewAnimator', 'ViewFlipper', 'ViewStub', 'WebView', 'android.gesture.GestureOverlayView', 'android.inputmethodservice.KeyboardView', 'android.opengl.GLSurfaceView', 'android.preference.PreferenceFrameLayout', 'android.support.v4.app.FragmentPager', 'android.support.v4.view.ViewPager', 'android.support.v7.widget.CardView', 'android.support.v7.widget.RecyclerView', 'android.support.wearable.view.DelayedConfirmationView', 'android.widget.RadialTimePickerView', 'com.android.internal.widget.ActionBarContainer', 'com.android.internal.widget.DialogTitle', 'com.android.internal.widget.PreferenceImageView', 'com.example.android.activityscenetransitionbasic.SquareFrameLayout', 'com.example.android.apis.accessibility.TaskListView', 'com.example.android.apis.text.LogTextBox', 'com.example.android.apis.view.GameView', 'com.example.android.apis.view.HoverInterceptorView', 'com.example.android.apis.view.LabelView', 'com.example.android.common.view.SlidingTabLayout', 'com.example.android.hdrviewfinder.FixedAspectSurfaceView', 'com.example.android.home.ApplicationsStackLayout', 'com.example.android.tictactoe.library.GameView', 'com.example.android.visualgamecontroller.ControllerView', 'com.example.android.xyztouristattractions.ui.AttractionsRecyclerView', 'com.google.android.maps.MapView', 'fragment', 'include', 'view'],
+\ {'android:addStatesFromChildren': [], 'android:background': [], 'android:baselineAligned': [], 'android:baselineAlignedChildIndex': [], 'android:clickable': [], 'android:clipToPadding': [], 'android:contentDescription': [], 'android:divider': [], 'android:dividerPadding': [], 'android:duplicateParentState': [], 'android:elevation': [], 'android:ellipsize': [], 'android:enabled': [], 'android:fillViewport': [], 'android:fitsSystemWindows': [], 'android:focusable': [], 'android:focusableInTouchMode': [], 'android:gravity': [], 'android:id': [], 'android:importantForAccessibility': [], 'android:layoutDirection': [], 'android:layout_alignBaseline': [], 'android:layout_alignBottom': [], 'android:layout_alignLeft': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentEnd': [], 'android:layout_alignParentLeft': [], 'android:layout_alignParentRight': [], 'android:layout_alignStart': [], 'android:layout_alwaysShow': [], 'android:layout_below': [], 'android:layout_centerHorizontal': [], 'android:layout_centerInParent': [], 'android:layout_centerVertical': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_ignoreOffset': [], 'android:layout_margin': [], 'android:layout_marginBottom': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_removeBorders': [], 'android:layout_toEndOf': [], 'android:layout_toLeftOf': [], 'android:layout_toRightOf': [], 'android:layout_toStartOf': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:measureWithLargestChild': [], 'android:minHeight': [], 'android:minWidth': [], 'android:mode': [], 'android:orientation': [], 'android:padding': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:scaleType': [], 'android:showDividers': [], 'android:splitMotionEvents': [], 'android:tag': [], 'android:textAppearance': [], 'android:translationZ': [], 'android:visibility': [], 'android:weightSum': [], 'internal:layout_maxHeight': [], 'internal:layout_minHeight': [], 'style': [], 'support:layout_box': [], 'tools:context': [], 'tools:ignore': []}
+\ ],
+\ 'GridLayout': [
+\ ['Button', 'CheckBox', 'EditText', 'ImageView', 'LinearLayout', 'RelativeLayout', 'Space', 'TextView', 'com.android.internal.widget.DigitalClock', 'com.android.internal.widget.LockPatternView', 'com.android.internal.widget.PasswordEntryKeyboardView', 'com.android.internal.widget.multiwaveview.MultiWaveView', 'include'],
+\ {'android:alignmentMode': [], 'android:animateLayoutChanges': [], 'android:background': [], 'android:clipChildren': [], 'android:columnCount': [], 'android:columnOrderPreserved': [], 'android:gravity': [], 'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_width': [], 'android:orientation': [], 'android:padding': [], 'android:rowCount': [], 'android:rowOrderPreserved': [], 'android:useDefaultMargins': []}
+\ ],
+\ 'android.widget.DayPickerViewPager': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'attr': [
+\ ['enum'],
+\ {'format': [], 'name': []}
+\ ],
+\ 'restriction': [
+\ [],
+\ {'android:defaultValue': [], 'android:description': [], 'android:entries': [], 'android:entryValues': [], 'android:key': [], 'android:restrictionType': [], 'android:title': []}
+\ ],
+\ 'changeClipBounds': [
+\ [],
+\ {}
+\ ],
+\ 'com.example.android.tictactoe.library.GameView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_margin': [], 'android:layout_weight': [], 'android:layout_width': []}
+\ ],
+\ 'com.example.android.apis.view.GameView': [
+\ [],
+\ {'android:background': [], 'android:id': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:padding': []}
+\ ],
+\ 'i': [
+\ [],
+\ {}
+\ ],
+\ 'android.support.v4.app.FragmentPager': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': []}
+\ ],
+\ 'TextureView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'appwidget-provider': [
+\ [],
+\ {'android:configure': [], 'android:initialLayout': [], 'android:minHeight': [], 'android:minResizeHeight': [], 'android:minResizeWidth': [], 'android:minWidth': [], 'android:previewImage': [], 'android:resizeMode': [], 'android:updatePeriodMillis': []}
+\ ],
+\ 'enum': [
+\ [],
+\ {'name': [], 'value': []}
+\ ],
+\ 'com.android.internal.widget.PasswordEntryKeyboardView': [
+\ [],
+\ {'android:background': [], 'android:clickable': [], 'android:id': [], 'android:keyBackground': [], 'android:layout_height': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginTop': [], 'android:layout_rowSpan': [], 'android:layout_width': [], 'android:paddingBottom': [], 'android:paddingTop': [], 'android:visibility': []}
+\ ],
+\ 'TableLayout': [
+\ ['TableRow', 'View'],
+\ {'android:animationCache': [], 'android:clipToPadding': [], 'android:collapseColumns': [], 'android:id': [], 'android:layoutAnimation': [], 'android:layout_height': [], 'android:layout_width': [], 'android:padding': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:shrinkColumns': [], 'android:stretchColumns': []}
+\ ],
+\ 'input-method': [
+\ ['subtype'],
+\ {'android:settingsActivity': [], 'android:supportsSwitchingToNextInputMethod': []}
+\ ],
+\ 'ZoomControls': [
+\ [],
+\ {'android:background': [], 'android:gravity': [], 'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_width': [], 'style': []}
+\ ],
+\ 'CheckedTextView': [
+\ [],
+\ {'android:background': [], 'android:checkMark': [], 'android:checkMarkGravity': [], 'android:drawablePadding': [], 'android:drawableStart': [], 'android:ellipsize': [], 'android:gravity': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:lines': [], 'android:minHeight': [], 'android:paddingEnd': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:singleLine': [], 'android:textAlignment': [], 'android:textAppearance': [], 'android:textColor': [], 'style': []}
+\ ],
+\ 'PreferenceCategory': [
+\ ['CheckBoxPreference', 'EditTextPreference', 'ListPreference', 'PreferenceScreen'],
+\ {'android:key': [], 'android:title': []}
+\ ],
+\ 'com.example.android.apis.text.LogTextBox': [
+\ [],
+\ {'android:background': [], 'android:id': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:scrollbars': []}
+\ ],
+\ 'ImageSwitcher': [
+\ [],
+\ {'android:id': [], 'android:layout_alignParentLeft': [], 'android:layout_alignParentTop': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'android.support.wearable.view.BoxInsetLayout': [
+\ ['LinearLayout', 'RelativeLayout', 'TextView', 'android.support.wearable.view.WearableListView'],
+\ {'android:background': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'transform': [
+\ [],
+\ {}
+\ ],
+\ 'Button': [
+\ ['requestFocus'],
+\ {'android:alpha': [], 'android:background': [], 'android:clickable': [], 'android:drawableLeft': [], 'android:drawablePadding': [], 'android:ellipsize': [], 'android:enabled': [], 'android:filterTouchesWhenObscured': [], 'android:focusable': [], 'android:fontFamily': [], 'android:gravity': [], 'android:id': [], 'android:layout_above': [], 'android:layout_alignEnd': [], 'android:layout_alignLeft': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentEnd': [], 'android:layout_alignParentLeft': [], 'android:layout_alignParentRight': [], 'android:layout_alignParentStart': [], 'android:layout_alignParentTop': [], 'android:layout_alignRight': [], 'android:layout_alignStart': [], 'android:layout_alignTop': [], 'android:layout_below': [], 'android:layout_centerHorizontal': [], 'android:layout_centerInParent': [], 'android:layout_centerVertical': [], 'android:layout_column': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_margin': [], 'android:layout_marginBottom': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_row': [], 'android:layout_toLeftOf': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:marqueeRepeatLimit': [], 'android:maxLines': [], 'android:minEms': [], 'android:minHeight': [], 'android:minWidth': [], 'android:nextFocusDown': [], 'android:nextFocusForward': [], 'android:nextFocusLeft': [], 'android:nextFocusRight': [], 'android:nextFocusUp': [], 'android:onClick': [], 'android:padding': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:singleLine': [], 'android:text': [], 'android:textAllCaps': [], 'android:textAppearance': [], 'android:textColor': [], 'android:textSize': [], 'android:textStyle': [], 'android:visibility': [], 'android_layout_gravity': [], 'style': []}
+\ ],
+\ 'skip': [
+\ [],
+\ {}
+\ ],
+\ 'integer': [
+\ [],
+\ {'name': []}
+\ ],
+\ 'EditTextPreference': [
+\ [],
+\ {'android:defaultValue': [], 'android:dependency': [], 'android:dialogTitle': [], 'android:inputType': [], 'android:key': [], 'android:layout': [], 'android:name': [], 'android:password': [], 'android:summary': [], 'android:title': []}
+\ ],
+\ 'TimePicker': [
+\ [],
+\ {'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'com.android.internal.widget.DialogTitle': [
+\ [],
+\ {'android:ellipsize': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:singleLine': [], 'android:text': [], 'android:textAlignment': [], 'style': []}
+\ ],
+\ 'HorizontalScrollView': [
+\ ['LinearLayout', 'TabWidget', 'TextView'],
+\ {'android:fillViewport': [], 'android:layout_height': [], 'android:layout_width': [], 'android:scrollbars': []}
+\ ],
+\ 'fade': [
+\ ['targets'],
+\ {'android:fadingMode': []}
+\ ],
+\ 'ContactsDataKind': [
+\ [],
+\ {'android:detailColumn': [], 'android:detailSocialSummary': [], 'android:icon': [], 'android:mimeType': [], 'android:summaryColumn': []}
+\ ],
+\ 'android.gesture.GestureOverlayView': [
+\ [],
+\ {'android:gestureStrokeType': [], 'android:id': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': []}
+\ ],
+\ 'Program': [
+\ [],
+\ {'content_rating': [], 'description': [], 'duration_sec': [], 'poster_art_url': [], 'title': [], 'video_type': [], 'video_url': []}
+\ ],
+\ 'MultiSelectListPreference': [
+\ [],
+\ {'android:entries': [], 'android:entryValues': [], 'android:key': [], 'android:title': []}
+\ ],
+\ 'android.preference.PreferenceFrameLayout': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': []}
+\ ],
+\ 'com.example.android.apis.view.CheckableFrameLayout': [
+\ ['TextView'],
+\ {'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'objectAnimator': [
+\ ['propertyValuesHolder'],
+\ {'android:duration': [], 'android:interpolator': [], 'android:propertyName': [], 'android:repeatCount': [], 'android:repeatMode': [], 'android:valueFrom': [], 'android:valueTo': [], 'android:valueType': []}
+\ ],
+\ 'com.example.android.basicmultitouch.TouchDisplayView': [
+\ [],
+\ {'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'allowed_callers': [
+\ ['signing_certificate'],
+\ {}
+\ ],
+\ 'TabWidget': [
+\ [],
+\ {'android:gravity': [], 'android:id': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:orientation': [], 'style': []}
+\ ],
+\ 'android.support.wearable.view.DelayedConfirmationView': [
+\ [],
+\ {'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_width': [], 'android:src': [], 'support:circle_border_color': [], 'support:circle_border_width': [], 'support:circle_color': [], 'support:circle_padding': [], 'support:circle_radius': [], 'support:circle_radius_pressed': []}
+\ ],
+\ 'com.example.android.apis.view.DraggableDot': [
+\ [],
+\ {'android:id': [], 'android:layout_alignLeft': [], 'android:layout_alignTop': [], 'android:layout_below': [], 'android:layout_height': [], 'android:layout_toRightOf': [], 'android:layout_width': [], 'android:padding': [], 'android:visibility': [], 'app:anr': [], 'app:legend': [], 'app:radius': []}
+\ ],
+\ 'set': [
+\ ['alpha', 'objectAnimator', 'rotate', 'scale', 'set', 'translate'],
+\ {'android:fillAfter': [], 'android:interpolator': [], 'android:shareInterpolator': [], 'android:startOffset': [], 'android:zAdjustment': []}
+\ ],
+\ 'plurals': [
+\ ['item'],
+\ {'name': []}
+\ ],
+\ 'com.android.internal.view.menu.IconMenuItemView': [
+\ [],
+\ {'android:ellipsize': [], 'android:fadingEdge': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:paddingStart': [], 'android:singleLine': []}
+\ ],
+\ 'Channel': [
+\ ['Program'],
+\ {'display_name': [], 'display_number': [], 'logo_url': [], 'video_height': [], 'video_width': []}
+\ ],
+\ 'ignore': [
+\ [],
+\ {}
+\ ],
+\ 'keyframe': [
+\ [],
+\ {'android:fraction': [], 'android:interpolator': [], 'android:value': []}
+\ ],
+\ 'FrameLayout': [
+\ ['Button', 'CheckBox', 'FrameLayout', 'GridLayout', 'GridView', 'ImageButton', 'ImageView', 'LinearLayout', 'ListView', 'ProgressBar', 'RelativeLayout', 'ScrollView', 'SeekBar', 'TextView', 'TextureView', 'VideoView', 'View', 'ViewStub', 'WebView', 'android.inputmethodservice.ExtractButton', 'android.opengl.GLSurfaceView', 'android.support.v7.widget.CardView', 'android.support.wearable.view.DismissOverlayView', 'android.support.wearable.view.DotsPageIndicator', 'android.support.wearable.view.GridViewPager', 'android.support.wearable.view.WatchViewStub', 'android.widget.DayPickerViewPager', 'com.android.internal.widget.ActionBarContainer', 'com.example.android.basicmultitouch.TouchDisplayView', 'com.example.android.displayingbitmaps.ui.RecyclingImageView', 'com.example.android.floatingactionbuttonbasic.FloatingActionButton', 'com.example.android.input.multitouch.basicMultitouch.TouchDisplayView', 'com.example.android.jetboy.JetBoyView', 'com.example.android.lunarlander.LunarView', 'com.example.android.snake.SnakeView', 'com.google.android.exoplayer.text.SubtitleView', 'fragment', 'include', 'view'],
+\ {'android:addStatesFromChildren': [], 'android:animateLayoutChanges': [], 'android:background': [], 'android:clipChildren': [], 'android:clipToPadding': [], 'android:fitsSystemWindows': [], 'android:focusable': [], 'android:foreground': [], 'android:foregroundGravity': [], 'android:foregroundInsidePadding': [], 'android:gravity': [], 'android:id': [], 'android:keepScreenOn': [], 'android:layout_above': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentEnd': [], 'android:layout_alignParentStart': [], 'android:layout_alignParentTop': [], 'android:layout_below': [], 'android:layout_centerHorizontal': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_margin': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginStart': [], 'android:layout_marginTop': [], 'android:layout_toRightOf': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:minHeight': [], 'android:minWidth': [], 'android:orientation': [], 'android:padding': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:tag': [], 'android:transitionName': [], 'android:visibility': [], 'internal:layout_maxHeight': [], 'internal:layout_minHeight': [], 'style': [], 'tools:context': [], 'tools:ignore': []}
+\ ],
+\ 'com.android.internal.widget.ActionBarOverlayLayout': [
+\ ['FrameLayout', 'com.android.internal.widget.ActionBarContainer'],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:splitMotionEvents': [], 'android:theme': []}
+\ ],
+\ 'com.example.android.customchoicelist.CheckableLinearLayout': [
+\ ['ImageView', 'TextView'],
+\ {'android:gravity': [], 'android:layout_height': [], 'android:layout_width': [], 'android:minHeight': [], 'android:orientation': [], 'android:paddingLeft': [], 'android:paddingRight': []}
+\ ],
+\ 'SeekBar': [
+\ [],
+\ {'android:enabled': [], 'android:id': [], 'android:layout_alignParentBottom': [], 'android:layout_alignParentEnd': [], 'android:layout_alignParentLeft': [], 'android:layout_alignParentRight': [], 'android:layout_alignParentStart': [], 'android:layout_below': [], 'android:layout_centerVertical': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_margin': [], 'android:layout_marginBottom': [], 'android:layout_marginEnd': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_toEndOf': [], 'android:layout_toLeftOf': [], 'android:layout_toRightOf': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:max': [], 'android:orientation': [], 'android:padding': [], 'android:paddingEnd': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:progress': [], 'android:secondaryProgress': [], 'style': []}
+\ ],
+\ 'alpha': [
+\ [],
+\ {'android:duration': [], 'android:fromAlpha': [], 'android:interpolator': [], 'android:startOffset': [], 'android:toAlpha': []}
+\ ],
+\ 'com.google.android.maps.MapView': [
+\ [],
+\ {'android:apiKey': [], 'android:clickable': [], 'android:enabled': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'uses-policies': [
+\ ['disable-camera', 'disable-keyguard-features', 'encrypted-storage', 'expire-password', 'force-lock', 'limit-password', 'reset-password', 'watch-login', 'wipe-data'],
+\ {}
+\ ],
+\ 'ScrollView': [
+\ ['GridLayout', 'LinearLayout', 'RadioGroup', 'RelativeLayout', 'TableLayout', 'TextView', 'com.example.android.batchstepsensor.cardstream.CardStreamLinearLayout', 'com.example.android.common.logger.LogView'],
+\ {'android:background': [], 'android:clipToPadding': [], 'android:fillViewport': [], 'android:gravity': [], 'android:id': [], 'android:layout_above': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginTop': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:orientation': [], 'android:overScrollMode': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:paddingStart': [], 'android:paddingTop': [], 'android:scrollbarSize': [], 'android:scrollbarStyle': [], 'android:scrollbarThumbVertical': [], 'android:scrollbarTrackVertical': [], 'android:scrollbars': [], 'style': [], 'tools:context': [], 'tools:ignore': []}
+\ ],
+\ 'com.example.android.common.view.SlidingTabLayout': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'com.example.android.renderscriptintrinsic.ThumbnailRadioButton': [
+\ [],
+\ {'android:checked': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:text': []}
+\ ],
+\ 'color': [
+\ [],
+\ {'name': []}
+\ ],
+\ 'DateTimeView': [
+\ [],
+\ {'android:gravity': [], 'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:paddingLeft': [], 'android:paddingStart': [], 'android:singleLine': [], 'android:textAppearance': []}
+\ ],
+\ 'com.android.internal.widget.ActionBarView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'style': []}
+\ ],
+\ 'arcMotion': [
+\ [],
+\ {}
+\ ],
+\ 'com.android.internal.view.menu.ActionMenuView': [
+\ [],
+\ {'android:divider': [], 'android:dividerPadding': [], 'android:gravity': [], 'android:layout_height': [], 'android:layout_width': []}
+\ ],
+\ 'layoutAnimation': [
+\ [],
+\ {'android:animation': [], 'android:animationOrder': [], 'android:delay': []}
+\ ],
+\ 'searchable': [
+\ [],
+\ {'android:hint': [], 'android:includeInGlobalSearch': [], 'android:label': [], 'android:searchMode': [], 'android:searchSettingsDescription': [], 'android:searchSuggestAuthority': [], 'android:searchSuggestIntentAction': [], 'android:searchSuggestIntentData': [], 'android:searchSuggestSelection': [], 'android:searchSuggestThreshold': [], 'android:voiceLanguageModel': [], 'android:voicePromptText': [], 'android:voiceSearchMode': []}
+\ ],
+\ 'dimen': [
+\ [],
+\ {'name': []}
+\ ],
+\ 'com.example.android.batchstepsensor.cardstream.CardActionButton': [
+\ [],
+\ {'android:gravity': [], 'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'style': []}
+\ ],
+\ 'QuickContactBadge': [
+\ [],
+\ {'android:id': [], 'android:layout_alignParentLeft': [], 'android:layout_alignParentTop': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_marginTop': [], 'android:layout_width': [], 'android:src': [], 'style': []}
+\ ],
+\ 'ListView': [
+\ ['requestFocus'],
+\ {'android:background': [], 'android:cacheColorHint': [], 'android:choiceMode': [], 'android:clipChildren': [], 'android:clipToPadding': [], 'android:divider': [], 'android:drawSelectorOnTop': [], 'android:elevation': [], 'android:fastScrollEnabled': [], 'android:id': [], 'android:layoutAnimation': [], 'android:layout_alignLeft': [], 'android:layout_below': [], 'android:layout_height': [], 'android:layout_marginBottom': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:listPreferredItemHeight': [], 'android:listSelector': [], 'android:nestedScrollingEnabled': [], 'android:overScrollMode': [], 'android:padding': [], 'android:paddingBottom': [], 'android:paddingLeft': [], 'android:paddingRight': [], 'android:paddingTop': [], 'android:persistentDrawingCache': [], 'android:scrollIndicators': [], 'android:scrollbarAlwaysDrawVerticalTrack': [], 'android:scrollbarStyle': [], 'android:smoothScrollbar': [], 'android:stackFromBottom': [], 'android:transcriptMode': [], 'android:visibility': [], 'style': []}
+\ ],
+\ 'spell-checker': [
+\ ['subtype'],
+\ {'android:label': [], 'android:settingsActivity': []}
+\ ],
+\ 'com.example.android.xyztouristattractions.ui.AttractionsRecyclerView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'android:scrollbars': []}
+\ ],
+\ 'string-array': [
+\ ['item'],
+\ {'name': [], 'translatable': [], 'translateable': []}
+\ ],
+\ 'group': [
+\ ['item'],
+\ {'android:checkableBehavior': [], 'android:id': [], 'android:menuCategory': [], 'android:visible': []}
+\ ],
+\ 'path': [
+\ ['pathelement'],
+\ {'android:fillColor': [], 'android:pathData': [], 'id': []}
+\ ],
+\ 'TwoLineListItem': [
+\ ['TextView'],
+\ {'android:background': [], 'android:layout_height': [], 'android:layout_weight': [], 'android:layout_width': [], 'android:minHeight': [], 'android:mode': [], 'android:paddingBottom': [], 'android:paddingEnd': [], 'android:paddingLeft': [], 'android:paddingStart': [], 'android:paddingTop': []}
+\ ],
+\ 'com.example.android.home.ApplicationsStackLayout': [
+\ [],
+\ {'android:background': [], 'android:id': [], 'android:layout_height': [], 'android:layout_marginTop': [], 'android:layout_width': [], 'home:marginLeft': [], 'home:marginRight': [], 'home:stackOrientation': []}
+\ ],
+\ 'DatePicker': [
+\ [],
+\ {'android:calendarViewShown': [], 'android:id': [], 'android:layout_gravity': [], 'android:layout_height': [], 'android:layout_width': [], 'android:spinnersShown': []}
+\ ],
+\ 'com.example.android.snake.SnakeView': [
+\ [],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'tileSize': []}
+\ ],
+\ 'integer-array': [
+\ ['item'],
+\ {'name': []}
+\ ],
+\ 'layer-list': [
+\ ['item'],
+\ {}
+\ ],
+\ 'transition': [
+\ ['targets'],
+\ {'android:duration': [], 'android:fromScene': [], 'android:interpolator': [], 'android:toScene': [], 'android:transition': [], 'class': []}
+\ ],
+\ 'solid': [
+\ [],
+\ {'android:color': []}
+\ ],
+\ 'sync-adapter': [
+\ [],
+\ {'android:accountType': [], 'android:allowParallelSyncs': [], 'android:contentAuthority': [], 'android:isAlwaysSyncable': [], 'android:supportsUploading': [], 'android:userVisible': []}
+\ ],
+\ 'transitionSet': [
+\ ['changeBounds', 'changeClipBounds', 'changeImageTransform', 'changeTransform', 'explode', 'fade', 'transition'],
+\ {'android:startDelay': [], 'android:transitionOrdering': []}
+\ ],
+\ 'array': [
+\ ['item'],
+\ {'name': []}
+\ ],
+\ 'com.example.android.batchstepsensor.cardstream.CardLayout': [
+\ ['LinearLayout', 'View'],
+\ {'android:id': [], 'android:layout_height': [], 'android:layout_width': [], 'style': []}
+\ ],
+\ 'android.inputmethodservice.KeyboardView': [
+\ [],
+\ {'android:background': [], 'android:id': [], 'android:keyPreviewLayout': [], 'android:keyTextSize': [], 'android:layout_alignParentBottom': [], 'android:layout_height': [], 'android:layout_width': [], 'android:popupLayout': []}
+\ ],
+\ 'project': [
+\ ['path', 'property', 'setup', 'taskdef'],
+\ {'default': [], 'name': []}
+\ ],
+\ 'android.support.v7.widget.CardView': [
+\ ['LinearLayout', 'TextView'],
+\ {'android:elevation': [], 'android:id': [], 'android:layout_height': [], 'android:layout_marginLeft': [], 'android:layout_marginRight': [], 'android:layout_width': [], 'style': [], 'support:cardBackgroundColor': [], 'support:cardCornerRadius': []}
+\ ],
+\ 'ListPreference': [
+\ [],
+\ {'android:defaultValue': [], 'android:dialogTitle': [], 'android:entries': [], 'android:entryValues': [], 'android:key': [], 'android:summary': [], 'android:title': []}
+\ ],
+\ 'vector': [
+\ ['path'],
+\ {'android:height': [], 'android:viewportHeight': [], 'android:viewportWidth': [], 'android:width': []}
+\ ],
+\ 'reset-password': [
+\ [],
+\ {}
+\ ],
+\ 'bind': [
+\ ['map', 'transform'],
+\ {}
+\ ],
+\ 'xliff:g': [
+\ [],
+\ {'id': []}
+\ ],
+\ 'force-lock': [
+\ [],
+\ {}
+\ ],
+\ 'taskdef': [
+\ [],
+\ {'classname': [], 'classpathref': [], 'name': []}
+\ ],
+\ }

--- a/autoload/xml/manifest.vim
+++ b/autoload/xml/manifest.vim
@@ -1,0 +1,91 @@
+" Vim XML data file
+" Last Change: 2015-09-15
+
+let g:xmldata_manifest = {
+\ 'vimxmlentities': ['lt', 'gt', 'amp', 'apos', 'quot'],
+\ 'vimxmlroot': ['manifest'],
+\ 'activity': [
+\ ['intent-filter', 'meta-data'],
+\ {'android:allowEmbedded': [], 'android:configChanges': [], 'android:enabled': [], 'android:excludeFromRecents': [], 'android:exported': [], 'android:hardwareAccelerated': [], 'android:icon': [], 'android:label': [], 'android:launchMode': [], 'android:logo': [], 'android:name': [], 'android:noHistory': [], 'android:parentActivityName': [], 'android:persistableMode': [], 'android:relinquishTaskIdentity': [], 'android:screenOrientation': [], 'android:stateNotNeeded': [], 'android:taskAffinity': [], 'android:theme': [], 'android:uiOptions': [], 'android:windowSoftInputMode': []}
+\ ],
+\ 'data': [
+\ [],
+\ {'android:host': [], 'android:mimeType': [], 'android:scheme': [], 'android:ssp': []}
+\ ],
+\ 'meta-data': [
+\ [],
+\ {'android:name': [], 'android:resource': [], 'android:value': []}
+\ ],
+\ 'category': [
+\ [],
+\ {'android:name': []}
+\ ],
+\ 'uses-feature': [
+\ [],
+\ {'android:glEsVersion': [], 'android:name': [], 'android:required': []}
+\ ],
+\ 'uses-permission-sdk-m': [
+\ [],
+\ {'android:name': []}
+\ ],
+\ 'action': [
+\ [],
+\ {'android:name': []}
+\ ],
+\ 'application': [
+\ ['activity', 'activity-alias', 'meta-data', 'provider', 'receiver', 'service', 'uses-library'],
+\ {'android:allowBackup': [], 'android:backupAgent': [], 'android:debuggable': [], 'android:description': [], 'android:fullBackupContent': [], 'android:hardwareAccelerated': [], 'android:icon': [], 'android:label': [], 'android:logo': [], 'android:name': [], 'android:persistent': [], 'android:supportsRtl': [], 'android:theme': []}
+\ ],
+\ 'instrumentation': [
+\ [],
+\ {'android:label': [], 'android:name': [], 'android:targetPackage': []}
+\ ],
+\ 'activity-alias': [
+\ ['intent-filter'],
+\ {'android:label': [], 'android:name': [], 'android:targetActivity': []}
+\ ],
+\ 'receiver': [
+\ ['intent-filter', 'meta-data'],
+\ {'android:description': [], 'android:enabled': [], 'android:exported': [], 'android:label': [], 'android:name': [], 'android:permission': [], 'android:process': []}
+\ ],
+\ 'supports-screens': [
+\ [],
+\ {'android:compatibleWidthLimitDp': [], 'android:largeScreens': [], 'android:requiresSmallestWidthDp': []}
+\ ],
+\ 'uses-library': [
+\ [],
+\ {'android:name': [], 'android:required': []}
+\ ],
+\ 'uses-permission': [
+\ [],
+\ {'android:name': []}
+\ ],
+\ 'permission': [
+\ [],
+\ {'android:name': []}
+\ ],
+\ 'provider': [
+\ ['grant-uri-permission', 'intent-filter'],
+\ {'android:authorities': [], 'android:enabled': [], 'android:exported': [], 'android:grantUriPermissions': [], 'android:name': [], 'android:permission': []}
+\ ],
+\ 'manifest': [
+\ ['application', 'instrumentation', 'meta-data', 'permission', 'supports-screens', 'uses-feature', 'uses-permission', 'uses-permission-sdk-m', 'uses-sdk'],
+\ {'android:uiOptions': [], 'android:versionCode': [], 'android:versionName': [], 'package': []}
+\ ],
+\ 'intent-filter': [
+\ ['action', 'category', 'data'],
+\ {'android:label': []}
+\ ],
+\ 'uses-sdk': [
+\ [],
+\ {'android:minSdkVersion': [], 'android:targetSdkVersion': [], 'minSdkVersion': []}
+\ ],
+\ 'grant-uri-permission': [
+\ [],
+\ {'android:pathPattern': []}
+\ ],
+\ 'service': [
+\ ['intent-filter', 'meta-data'],
+\ {'android:allowEmbedded': [], 'android:enabled': [], 'android:exported': [], 'android:isolatedProcess': [], 'android:label': [], 'android:name': [], 'android:permission': [], 'android:process': [], 'android:stopWithTask': [], 'android:taskAffinity': []}
+\ ],
+\ }

--- a/plugin/gradle.vim
+++ b/plugin/gradle.vim
@@ -10,4 +10,4 @@ function! GradleAirlineInit()
 endfunction
 
 autocmd User AirlineAfterInit call GradleAirlineInit()
-
+autocmd BufEnter AndroidManifest.xml XMLns manifest


### PR DESCRIPTION
This commit enhances vim's native XML completion to account for most of
the keywords that an Android xml file will contain. This also removes
where vim-android started classpath completion during an XML file. Since
XML files can't currently use Java classpaths we can save that for when
a Java file is being editted so things don't slow down.