### PR TITLE
Fix separator between $CLASSPATH and $SRCPATH

### DIFF
--- a/after/ftplugin/java.vim
+++ b/after/ftplugin/java.vim
@@ -19,4 +19,4 @@ if exists(":JCstart")
   let $SRCPATH = g:JavaComplete_SourcesPath
 endif
 
-let g:syntastic_java_javac_classpath = $CLASSPATH . $SRCPATH
+let g:syntastic_java_javac_classpath = $CLASSPATH . ":" . $SRCPATH


### PR DESCRIPTION
The final part of the classpaths was getting mangled because of lack of `:` separating the two.