### PR TITLE
Fixed s:setup() beign called multiple times in 	vimTaskHandler when using nvim

### DIFF
--- a/autoload/gradle.vim
+++ b/autoload/gradle.vim
@@ -327,9 +327,8 @@ function! s:vimTaskHandler(id, data, event)
     call s:finishBuilding()
     if a:data != 0
       call gradle#logi("Gradle sync task failed")
-    else
-      call s:setup()
     endif
+    call s:setup()
   endif
 endfunction
 

--- a/autoload/gradle.vim
+++ b/autoload/gradle.vim
@@ -327,10 +327,10 @@ function! s:vimTaskHandler(id, data, event)
     call s:finishBuilding()
     if a:data != 0
       call gradle#logi("Gradle sync task failed")
+    else
+      call s:setup()
     endif
   endif
-
-  call s:setup()
 endfunction
 
 function! s:parseVimTaskOutput(gradleFile, result)


### PR DESCRIPTION
Fixed s:setup() beign called multiple times in vimTaskHandler(id, data, event) when using nvim causing improper android library paths, for ex getSdkJar() returns '/home/user/Android/Sdk/platforms//android.jar' path with missing android version.