### PR TITLE
add exploded aar classes.jar files to build path

### DIFF
--- a/autoload/android.vim
+++ b/autoload/android.vim
@@ -206,6 +206,10 @@ function! android#getProjectJar()
   endif
 endfunction
 
+function! android#getAarJars()
+  return findfile('classes.jar', gradle#findRoot() . '/build/intermediates/exploded-aar/**', -1)
+endfunction
+
 function! android#getTargetVersion()
 
   let l:gradleFile = gradle#findGradleFile()
@@ -265,6 +269,11 @@ function! android#setClassPath()
 
   if len(l:projectJar) > 0
     call add(l:jarList, l:projectJar)
+  endif
+
+  let l:aarJars = android#getAarJars()
+  if len(l:aarJars) > 0
+    call extend(l:jarList, l:aarJars)
   endif
 
   let l:targetJar = android#getSdkJar()


### PR DESCRIPTION
Dependencies which are aars should be included in the build classpath.  Their class files are located in the `/build/intermediates/exploded-aar/.../jars/classes.jar`.