### PR TITLE
Allow gradle#findGradleFile() to also search for Kotlin DSL Gradle files

### DIFF
--- a/autoload/gradle.vim
+++ b/autoload/gradle.vim
@@ -131,6 +131,10 @@ function! gradle#findGradleFile()
   let l:file = findfile('build.gradle', l:path . ';$HOME')
 
   if len(l:file) == 0
+    let l:file = findfile('build.gradle.kts', l:path . ';$HOME')
+  endif
+
+  if len(l:file) == 0
     return ''
   endif
 


### PR DESCRIPTION
Hello there.

I am currently working on a mixed Java + Kotlin project that uses a Kotlin DSL Gradle file instead of the regular Groovy DSL ones.

This PR contains the hack I had to implement so that `gradle#sync()` does not fail with `File not found` when a project has a `build.gradle.kts` instead.

Hope the logic and syntax are acceptable.

Thank you for your time!