### PR TITLE
adding missing char in docs causing error

### DIFF
--- a/doc/vim-android.txt
+++ b/doc/vim-android.txt
@@ -416,7 +416,7 @@ Then you can add the parts to any airline section you want:
      \ 'filetype',
      \ 'gradle-running',
      \ 'gradle-errors',
-     \ 'gradle-warnings
+     \ 'gradle-warnings'
      \])
 <
 

--- a/doc/vim-android.txt
+++ b/doc/vim-android.txt
@@ -392,7 +392,22 @@ your vim configuration to create airline gradle parts:
 >
    call airline#parts#define_function(
        \ 'gradle-running',
-       \ 'gradle#running'
+       \ 'ligthline#gradle#running'
+       \)
+
+   call airline#parts#define_function(
+       \ 'gradle-errors',
+       \ 'ligthline#gradle#errors'
+       \)
+
+   call airline#parts#define_function(
+       \ 'gradle-warnings',
+       \ 'ligthline#gradle#warnings'
+       \)
+
+   call airline#parts#define_function(
+       \ 'gradle-project',
+       \ 'ligthline#gradle#project'
        \)
 <
 Then you can add the parts to any airline section you want:
@@ -400,6 +415,8 @@ Then you can add the parts to any airline section you want:
    let g:airline_section_x= airline#section#create_right([
      \ 'filetype',
      \ 'gradle-running',
+     \ 'gradle-errors',
+     \ 'gradle-warnings'
      \])
 <
 

--- a/doc/vim-android.txt
+++ b/doc/vim-android.txt
@@ -392,22 +392,7 @@ your vim configuration to create airline gradle parts:
 >
    call airline#parts#define_function(
        \ 'gradle-running',
-       \ 'ligthline#gradle#running'
-       \)
-
-   call airline#parts#define_function(
-       \ 'gradle-errors',
-       \ 'ligthline#gradle#errors'
-       \)
-
-   call airline#parts#define_function(
-       \ 'gradle-warnings',
-       \ 'ligthline#gradle#warnings'
-       \)
-
-   call airline#parts#define_function(
-       \ 'gradle-project',
-       \ 'ligthline#gradle#project'
+       \ 'gradle#running'
        \)
 <
 Then you can add the parts to any airline section you want:
@@ -415,8 +400,6 @@ Then you can add the parts to any airline section you want:
    let g:airline_section_x= airline#section#create_right([
      \ 'filetype',
      \ 'gradle-running',
-     \ 'gradle-errors',
-     \ 'gradle-warnings'
      \])
 <
 


### PR DESCRIPTION
vim users often copy-paste text from the help-docs to their vim configs.
The following pull request fixes the missing `'` at line 419 of doc/vim-android.txt.

I am available to help you.
Thanks
Best Regards
Fabrizio Bertoglio