### PR TITLE
Ensure 'has*' variables are defined where they are used

### DIFF
--- a/gradle/init.gradle
+++ b/gradle/init.gradle
@@ -127,6 +127,9 @@ allprojects { project ->
     }
 
     if( result.getFailure() != null ) {
+      def hasCheckstyle = project.getPlugins().hasPlugin('checkstyle')
+      def hasFindbugs   = project.getPlugins().hasPlugin('findbugs')
+      def hasPmd = project.getPlugins().hasPlugin('pmd')
 
       if(hasPmd) {
         project.tasks.withType(Pmd) { task ->


### PR DESCRIPTION
When I try to use the 'gradle' compiler, I sometimes get these messages:

"> Could not get unknown property 'hasPmd' for project ':projectName' of
type org.gradle.api.Project."

Defining the 'hasPmd' variable before it's used in the buildFinished
section fixes that. I also define the other two variables because it
seems like they should have a similar problem.