### PR TITLE
Fix 81 - AndroidInstall does nothing.

### DIFF
--- a/autoload/gradle.vim
+++ b/autoload/gradle.vim
@@ -678,7 +678,7 @@ function! s:nvim_job(cmd) abort
 
   call s:startBuilding()
 
-  let l:ch = jobstart(a:cmd, l:options)
+  let l:ch = jobstart(join(a:cmd), l:options)
   let s:chunks[l:ch] = ['']
   let s:files[l:ch] = l:gradleFile
 endfunction


### PR DESCRIPTION
Convert the command executed asynchronously to a string so it spawns a
shell when executing. If not the last part of the command are
interpreted as gradle tasks.