### PR TITLE
Mirakle Gradle Remote Build Support

### DIFF
--- a/autoload/android.vim
+++ b/autoload/android.vim
@@ -107,6 +107,21 @@ function! android#install(mode)
   endfor
 endfunction
 
+
+function! android#buildremotedebug()
+  call android#logi('Build Debug on Remote') 
+  let l:cmd = gradle#bin() . ' assembleDebug' 
+  execute '!' . l:cmd
+  redraw!
+endfunction
+
+function! android#buildremoterelease()
+  call android#logi('Build Release on Remote') 
+  let l:cmd = gradle#bin() . ' assemble' 
+  execute '!' . l:cmd
+  redraw!
+endfunction
+
 function! android#launch(mode)
 
   let l:devices = adb#selectDevice()
@@ -320,6 +335,8 @@ endfunction
 function! android#setupAndroidCommands()
   if android#checkAndroidHome()
     command! -nargs=+ Android call android#compile(<f-args>)
+    command!  AndroidMirakleDebug call android#buildremotedebug()
+    command!  AndroidMirakleRelease call android#buildremoterelease()
     command! -nargs=? AndroidBuild call android#compile(<f-args>)
     command! -nargs=1 AndroidInstall call android#install(<f-args>)
     command! -nargs=1 AndroidUninstall call android#uninstall(<f-args>)


### PR DESCRIPTION
Gradle only works on x86_64 and we are working on arm64 , use https://github.com/Adambl4/mirakle to build the apk on cloud.

If use AndroidBuild, it only works with local gradle.

You need configure: https://github.com/Adambl4/mirakle to build on remote.
![vim_arm3](https://user-images.githubusercontent.com/8399211/125207266-8f73e200-e28b-11eb-8c82-d85b803a7f5b.png)

