### PR TITLE
Aapt2 remote buildoutput

### DIFF
--- a/autoload/aapt.vim
+++ b/autoload/aapt.vim
@@ -4,13 +4,13 @@ function! aapt#bin()
     return g:android_aapt_tool
   endif
 
-  let g:android_aapt_tool = android#buildToolsPath() . '/aapt'
+  let g:android_aapt_tool = android#buildToolsPath() . '/aapt2'
 
   if(executable(g:android_aapt_tool))
     return g:android_aapt_tool
   endif
 
-  let g:android_aapt_tool='aapt'
+  let g:android_aapt_tool='aapt2'
 
   if(executable(g:android_aapt_tool))
     return g:android_aapt_tool

--- a/autoload/android.vim
+++ b/autoload/android.vim
@@ -107,6 +107,21 @@ function! android#install(mode)
   endfor
 endfunction
 
+
+function! android#buildremotedebug()
+  call android#logi('Build Debug on Remote') 
+  let l:cmd = gradle#bin() . ' assembleDebug' 
+  execute '!' . l:cmd
+  redraw!
+endfunction
+
+function! android#buildremoterelease()
+  call android#logi('Build Release on Remote') 
+  let l:cmd = gradle#bin() . ' assemble' 
+  execute '!' . l:cmd
+  redraw!
+endfunction
+
 function! android#launch(mode)
 
   let l:devices = adb#selectDevice()
@@ -320,6 +335,8 @@ endfunction
 function! android#setupAndroidCommands()
   if android#checkAndroidHome()
     command! -nargs=+ Android call android#compile(<f-args>)
+    command!  AndroidMirakleDebug call android#buildremotedebug()
+    command!  AndroidMirakleRelease call android#buildremoterelease()
     command! -nargs=? AndroidBuild call android#compile(<f-args>)
     command! -nargs=1 AndroidInstall call android#install(<f-args>)
     command! -nargs=1 AndroidUninstall call android#uninstall(<f-args>)

--- a/autoload/android.vim
+++ b/autoload/android.vim
@@ -110,16 +110,27 @@ endfunction
 
 function! android#buildremotedebug()
   call android#logi('Build Debug on Remote') 
-  let l:cmd = gradle#bin() . ' assembleDebug' 
-  execute '!' . l:cmd
-  redraw!
+  let l:cmd = gradle#bin() . ' assembleDebug ' 
+ " execute '!' . l:cmd
+ let winid = bufwinid('BuildOutput')
+  if winid > 0
+ call win_gotoid(winid)	  
+  bw! "BuildOutput"
+  endif
+ execute 'new BuildOutput | read ! ' . l:cmd 
+ " redraw!
 endfunction
 
 function! android#buildremoterelease()
   call android#logi('Build Release on Remote') 
-  let l:cmd = gradle#bin() . ' assemble' 
-  execute '!' . l:cmd
-  redraw!
+  let l:cmd = gradle#bin() . ' assemble ' 
+  " execute '!' . l:cmd
+ let winid = bufwinid('BuildOutput')
+  if winid > 0
+ call win_gotoid(winid)	  
+  bw! "BuildOutput"
+  endif
+  execute 'new BuildOutput | read ! ' . l:cmd
 endfunction
 
 function! android#launch(mode)
@@ -140,7 +151,7 @@ function! android#launch(mode)
     return
   endif
 
- let l:mainId = system(aapt#bin() . ' list -a ' . l:apk . ' | sed -n "/^Package Group[^s]/s/.*name=//p"  | sed "s/$/ 1/" ')
+ let l:mainId = system(aapt#bin() . ' dump packagename ' . l:apk . ' | sed "s/$/ 1/" ')
 
   for l:device in l:devices
     call android#logi("Install and Launch " . a:mode . " " . l:device)


### PR DESCRIPTION
-New way to get android package name compatible with AAPT2
-A problem to work with remote build is buildoutput, because we can check the errors for 500ms, now, the command open a new buffer to view the last log of gradle build on remote server