### PR TITLE
Adds test dependencies to stdout

### DIFF
--- a/gradle/init.gradle
+++ b/gradle/init.gradle
@@ -23,6 +23,14 @@ allprojects { project ->
               System.err.println "vim-gradle " + it
             }
           }
+
+          if(project.android.hasProperty('testVariants')) {
+            project.android.testVariants.all { variant ->
+              variant.getCompileClasspath().each {
+                System.err.println "vim-gradle " + it
+              }
+            }
+          }
         }
       } else {
         // Print build class directories. These assume the project follows a


### PR DESCRIPTION
Currently test dependencies in gradle (prefix androidTestImplementation or testImplementation) are not listed to stdout and thus the plugin doesn't parse them. This commit fixes that issue. 