### PR TITLE
Generate Classpath File

### DIFF
--- a/autoload/classpath.vim
+++ b/autoload/classpath.vim
@@ -1,0 +1,38 @@
+let s:entry = "\t<classpathentry kind=\"<kind>\" path=\"<path>\"/>"
+let s:entry_sourcepath = "\t<classpathentry kind=\"<kind>\" path=\"<path>\" sourcepath=\"<src>\"/>"
+
+" Creates a .classpath file and fills it with dependency entries
+function! classpath#generateClasspath() abort
+  let l:classes = gradle#classPaths()
+  let classpath = ['<?xml version="1.0" encoding="UTF-8"?>', '<classpath>']
+  for jar in l:classes
+    call add(classpath, s:newClassEntry('lib', jar))
+  endfor
+  call add(classpath, s:newClassEntry('src', 'src/main/java'))
+  call add(classpath, s:newClassEntry('lib', '.'))
+  call add(classpath, '</classpath>')
+  call writefile(classpath, gradle#findRoot() . '/.classpath')
+endfunction
+
+" Adds a new entry to the current .classpath file.
+function! s:newClassEntry(kind, arg, ...)
+  let template_name = 's:entry'
+  let args = {'kind': a:kind, 'path': substitute(a:arg, '\', '/', 'g')}
+
+  if a:0 == 1
+      let template_name = 's:entry_sourcepath'
+      let args['src'] = substitute(a:1, '\', '/', 'g')
+  endif
+
+  if exists(template_name . '_' . a:kind)
+    let template = {template_name}_{a:kind}
+  else
+    let template = {template_name}
+  endif
+
+  for [key, value] in items(args)
+    let template = substitute(template, '<' . key . '>', value, 'g')
+  endfor
+
+  return template
+endfunction

--- a/autoload/classpath.vim
+++ b/autoload/classpath.vim
@@ -4,13 +4,19 @@ let s:entry_sourcepath = "\t<classpathentry kind=\"<kind>\" path=\"<path>\" sour
 " Creates a .classpath file and fills it with dependency entries
 function! classpath#generateClasspath() abort
   let l:classes = gradle#classPaths()
+  let l:srcs = extend(gradle#sourcePaths(), android#sourcePaths())
+
   let classpath = ['<?xml version="1.0" encoding="UTF-8"?>', '<classpath>']
+  for src in l:srcs
+      let l:relativeSrc =  fnamemodify(src, ":s?" . gradle#findRoot() . "/??")
+      call add(classpath, s:newClassEntry('src', relativeSrc))
+  endfor
   for jar in l:classes
     call add(classpath, s:newClassEntry('lib', jar))
   endfor
-  call add(classpath, s:newClassEntry('src', 'src/main/java'))
   call add(classpath, s:newClassEntry('lib', '.'))
   call add(classpath, '</classpath>')
+
   call writefile(classpath, gradle#findRoot() . '/.classpath')
 endfunction
 

--- a/autoload/gradle.vim
+++ b/autoload/gradle.vim
@@ -545,6 +545,7 @@ function! gradle#setupGradleCommands()
     command! -nargs=+ Gradle call gradle#compile(<f-args>)
     command! GradleSync call gradle#sync()
     command! GradleInfo call gradle#output()
+    command! GradleGenClassPathFile call classpath#generateClasspath()
   else
     command! -nargs=? Gradle echoerr 'Gradle binary could not be found, vim-android gradle commands are disabled'
     command! GradleSync echoerr 'Gradle binary could not be found, vim-android gradle commands are disabled'

--- a/doc/vim-android.txt
+++ b/doc/vim-android.txt
@@ -145,6 +145,11 @@ COMMANDS                                                   *vim-android-commands
     available via command line can be used using this command (e.g. :Gradle
     build).
 
+:GradleGenClassPathFile
+    Creates a .classpath file with all gradle android dependencies and sources
+    in the subfolder app. This .classpath file is read by eclipse jdt language
+    server for lsp features.
+
 :Android <options>
     This is an alias to the Gradle command.
 


### PR DESCRIPTION
This commit adds a utility function to create a .classpath file under the subfolder app. After manually calling this function and creating the file and after a restart, the eclipse jdt.ls server reads and parses this .classpath file to provide its lsp features. It isn't perfect yet but works fairly well. Tried with coc-java and nvim-lspconfig.