### PR TITLE
Fix 113 - improve .classpath creation.

### DIFF
--- a/autoload/ale_linters/java.vim
+++ b/autoload/ale_linters/java.vim
@@ -29,24 +29,19 @@ function! ale_linters#java#EclipseLspNotifyConfigChange() abort
   let l:buffer = bufnr('%')
 
   if s:LoadedAle(l:buffer, 'eclipselsp')
-    let config =
+
+    let l:config = 
           \ {
-          \  'settings': {
-          \    'java': {
-          \      'project': {
-          \        'referencedLibraries': s:LoadDeps()
-          \      }
-          \    }
-          \  }
+          \    'uri': ale#path#ToFileURI(expand('%:p'))
           \ }
 
     call ale#lsp_linter#SendRequest(
           \ l:buffer,
           \ 'eclipselsp',
-          \ [ 0, 'workspace/didChangeConfiguration', l:config ])
+          \ [ 0, 'java/projectConfigurationUpdate', l:config ])
 
     call ale#lsp_linter#SendRequest(
-          \ bufnr('%'),
+          \ l:buffer,
           \ 'eclipselsp',
           \ ale#lsp#message#DidChange(l:buffer))
   endif
@@ -58,7 +53,7 @@ function! ale_linters#java#JavaLspNotifyConfigChange() abort
   let l:buffer = bufnr('%')
 
   if s:LoadedAle(l:buffer, 'javalsp')
-    let config =
+    let l:config =
           \ {
           \  'settings': {
           \    'java': {
@@ -74,7 +69,7 @@ function! ale_linters#java#JavaLspNotifyConfigChange() abort
           \ [ 0, 'workspace/didChangeConfiguration', l:config ])
 
     call ale#lsp_linter#SendRequest(
-          \ bufnr('%'),
+          \ l:buffer,
           \ 'javalsp',
           \ ale#lsp#message#DidChange(l:buffer))
   endif

--- a/autoload/classpath.vim
+++ b/autoload/classpath.vim
@@ -1,8 +1,21 @@
 let s:entry = "\t<classpathentry kind=\"<kind>\" path=\"<path>\"/>"
 let s:entry_sourcepath = "\t<classpathentry kind=\"<kind>\" path=\"<path>\" sourcepath=\"<src>\"/>"
 
-" Creates a .classpath file and fills it with dependency entries
 function! classpath#generateClasspathFile() abort
+
+  if !exists('g:gradle_gen_classpath_file')
+    let g:gradle_gen_classpath_file = 1
+  endif
+
+  if g:gradle_gen_classpath_file != 1
+    return
+  endif
+
+  call s:generateClasspathFile()
+endfunction
+
+" Creates a .classpath file and fills it with dependency entries
+function! s:generateClasspathFile() abort
 
   " For non android project JDT generated .classpath file works fine. No need to
   " fiddle with it. For android project in the other hand the JDT generated one
@@ -49,7 +62,6 @@ function! classpath#generateClasspathFile() abort
   endif
 
   call writefile(l:contents, l:path)
-  call ale_linters#java#EclipseLspNotifyConfigChange()
 endfunction
 
 " Generates .classpath file required by some tools to figure out dependencies

--- a/autoload/gradle.vim
+++ b/autoload/gradle.vim
@@ -420,6 +420,7 @@ function! gradle#sync() abort
     let l:id = s:BufWinId()
     call setloclist(l:id, [], ' ', s:What(l:result))
     call s:setClassPath()
+    call classpath#generateClasspathFile()
     call gradle#logi('')
     call ale_linters#java#NotifyConfigChange()
   endif
@@ -686,9 +687,9 @@ function! s:job_cb(id, data, event) abort
     call remove(s:chunks, a:id)
     call s:showLoclist()
     call s:setClassPath()
-    call s:generateClasspathFile()
+    call classpath#generateClasspathFile()
     call s:finishBuilding()
-    call ale_linters#java#JavaLspNotifyConfigChange()
+    call ale_linters#java#NotifyConfigChange()
   endif
 endfunction
 
@@ -767,17 +768,4 @@ function! s:setClassPath() abort
   " syntastic plugin.
   let g:syntastic_java_javac_classpath = $CLASSPATH . ':' . $SRCPATH
 
-endfunction
-
-function! s:generateClasspathFile() abort
-
-  if !exists('g:gradle_gen_classpath_file')
-    let g:gradle_gen_classpath_file = 1
-  endif
-
-  if g:gradle_gen_classpath_file != 1
-    return
-  endif
-
-  call classpath#generateClasspathFile()
 endfunction

--- a/autoload/gradle.vim
+++ b/autoload/gradle.vim
@@ -556,7 +556,7 @@ function! gradle#setupGradleCommands()
     command! -nargs=+ Gradle call gradle#compile(<f-args>)
     command! GradleSync call gradle#sync()
     command! GradleInfo call gradle#output()
-    command! GradleGenClassPathFile call classpath#generateClasspath()
+    command! GradleGenClassPathFile call classpath#generateClasspathFile()
   else
     command! -nargs=? Gradle echoerr 'Gradle binary could not be found, vim-android gradle commands are disabled'
     command! GradleSync echoerr 'Gradle binary could not be found, vim-android gradle commands are disabled'
@@ -686,8 +686,9 @@ function! s:job_cb(id, data, event) abort
     call remove(s:chunks, a:id)
     call s:showLoclist()
     call s:setClassPath()
+    call s:generateClasspathFile()
     call s:finishBuilding()
-    call ale_linters#java#NotifyConfigChange()
+    call ale_linters#java#JavaLspNotifyConfigChange()
   endif
 endfunction
 
@@ -766,4 +767,17 @@ function! s:setClassPath() abort
   " syntastic plugin.
   let g:syntastic_java_javac_classpath = $CLASSPATH . ':' . $SRCPATH
 
+endfunction
+
+function! s:generateClasspathFile() abort
+
+  if !exists('g:gradle_gen_classpath_file')
+    let g:gradle_gen_classpath_file = 1
+  endif
+
+  if g:gradle_gen_classpath_file != 1
+    return
+  endif
+
+  call classpath#generateClasspathFile()
 endfunction

--- a/doc/vim-android.txt
+++ b/doc/vim-android.txt
@@ -159,7 +159,7 @@ COMMANDS                                                   *vim-android-commands
     you get unknown references it may be necessary to restart the language
     server itself.
 
-    Warning: for now this commnad only works for Android projects. For non
+    Warning: for now this command only works for Android projects. For non
     Android projects this command has no effect.
 
 :Android <options>

--- a/doc/vim-android.txt
+++ b/doc/vim-android.txt
@@ -57,6 +57,7 @@ The following features are supported by vim-android:
   - Updates the SRCPATH environment variable to include source paths for the
     current project and dependencies if available. This allows debuggers like
     vebugger to follow source code during step debugging.
+  - Generates .classpath file that works with Android projects.
   - Adds useful commands to compile and install your application APK into
     your emulator/devices.
   - Improved XML omnicompletion for Android resource and manifest XML files.
@@ -146,9 +147,15 @@ COMMANDS                                                   *vim-android-commands
     build).
 
 :GradleGenClassPathFile
-    Creates a .classpath file with all gradle android dependencies and sources
-    in the subfolder app. This .classpath file is read by eclipse jdt language
-    server for lsp features.
+    Manually generate the .classpath file with all gradle dependencies and
+    sources in the subfolder app. This .classpath file is read by some tools
+    like Eclipse JDT language server for lsp features. Calling this command
+    generates the .classpath file no matter the value of the
+    |g:gradle_gen_classpath_file| configuration.
+
+    Note that it may be necessary to restart the language server in order for
+    it to pickup changes on the .classpath file. Also this command works only
+    for Android projects. For non-Android projects this command has no effect.
 
 :Android <options>
     This is an alias to the Gradle command.
@@ -520,6 +527,21 @@ variables.
 Example:
 >
         let g:gradle_set_classpath=0
+<
+                                                   *g:gradle_gen_classpath_file*
+g:gradle_gen_classpath_file~
+Default: 1
+
+This plugin will automatically generate a .classpath file with dependencies
+after gradle sync task completes. This file is used by some tools (e.g. JDT)
+to figure out dependencies for auto completion, auto import, and other useful
+functions. If you prefer to not generate this file then set this configuration
+variable to 0. Note that this file is generated only for Android projects. For
+non-Android projects this configuration has no effect.
+
+Example:
+>
+        let g:gradle_gen_classpath_file=0
 <
                                                         *g:gradle_show_signs*
 g:gradle_show_signs~

--- a/doc/vim-android.txt
+++ b/doc/vim-android.txt
@@ -148,14 +148,19 @@ COMMANDS                                                   *vim-android-commands
 
 :GradleGenClassPathFile
     Manually generate the .classpath file with all gradle dependencies and
-    sources in the subfolder app. This .classpath file is read by some tools
-    like Eclipse JDT language server for lsp features. Calling this command
-    generates the .classpath file no matter the value of the
-    |g:gradle_gen_classpath_file| configuration.
+    sources. This .classpath file is read by some tools like Eclipse JDT
+    language server for lsp features.
 
-    Note that it may be necessary to restart the language server in order for
-    it to pickup changes on the .classpath file. Also this command works only
-    for Android projects. For non-Android projects this command has no effect.
+    Note that this command is affected by |g:gradle_gen_classpath_file|
+    configuration.
+
+    After generating the .classpath file you may want to run |GradleSync| to
+    update the language servers (Eclipse JDT) configurations. If after this
+    you get unknown references it may be necessary to restart the language
+    server itself.
+
+    Warning: for now this commnad only works for Android projects. For non
+    Android projects this command has no effect.
 
 :Android <options>
     This is an alias to the Gradle command.
@@ -533,10 +538,12 @@ g:gradle_gen_classpath_file~
 Default: 1
 
 This plugin will automatically generate a .classpath file with dependencies
-after gradle sync task completes. This file is used by some tools (e.g. JDT)
-to figure out dependencies for auto completion, auto import, and other useful
-functions. If you prefer to not generate this file then set this configuration
-variable to 0. Note that this file is generated only for Android projects. For
+after gradle sync task completes for Android projects. This file is required
+for some language servers (e.g. Eclipse JDT) to figure out dependencies for
+auto completion, auto import, and other useful functions. If you prefer to not
+generate this file then set this configuration variable to 0.
+
+Note that the .classpath file is generated only for Android projects. For
 non-Android projects this configuration has no effect.
 
 Example:


### PR DESCRIPTION
- Automatically create the .classpath file for android projects.
- Add option to disable automatic creation of .classpath file for
  android projects.
- Disable .classpath file generation for non-android projects. The one
  generated by JDT works just fine for non android projects.
- Change Eclipse Notify method to send configuration update message
  instead of didChageConfiguration. The didChangeConfiguration was
  actually doing nothing.