### PR TITLE
use job#start() to make the emulator actually run

### DIFF
--- a/autoload/android.vim
+++ b/autoload/android.vim
@@ -314,8 +314,8 @@ function! android#emulator()
   let l:option = l:avds[l:choice]
   let l:avd = strpart(l:option, 3)
 
-  let l:options = {}
-  call job#start(android#emulatorbin() . ' -avd ' . l:avd . ' 2>/dev/null', l:options)
+  let l:options = { 'detach': 1 }
+  call jobstart(android#emulatorbin() . ' -avd ' . l:avd . ' 2>/dev/null', l:options)
   redraw!
 
 endfunction

--- a/autoload/android.vim
+++ b/autoload/android.vim
@@ -314,7 +314,8 @@ function! android#emulator()
   let l:option = l:avds[l:choice]
   let l:avd = strpart(l:option, 3)
 
-  execute 'silent !' . android#emulatorbin() . ' -avd ' . l:avd . ' 2>/dev/null  &'
+  let l:options = {}
+  call job#start(android#emulatorbin() . ' -avd ' . l:avd . ' 2>/dev/null', l:options)
   redraw!
 
 endfunction


### PR DESCRIPTION
I've been wondering why AndroidEmulator isn't running the emulator. So I decided to check out the source code. I found that using execute with & makes the emulator unable to run. Removing the &, the emulator runs but throws the log messages in your face which you obviously don't want. Then I found the job#start() function just laying around in **autoload/job.vim**. Used this with an empty options arg, and the emulator runs.